### PR TITLE
Prevent double-inclusion errors

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -7116,10 +7116,9 @@ _CONSTEXPR11 SafeInt< T, E > operator |( U lhs, SafeInt< T, E > rhs ) SAFEINT_NO
     return SafeInt< T, E >( BinaryOrHelper< T, U, BinaryMethod< T, U >::method >::Or( (T)rhs, lhs ) );
 }
 
-#endif //SAFEINT_HPP
-
 #if defined VISUAL_STUDIO_SAFEINT_COMPAT
 } // utilities
 } // msl
 #endif
 
+#endif //SAFEINT_HPP


### PR DESCRIPTION
If VISUAL_STUDIO_SAFEINT_COMPAT was defined, and SafeInt.hpp was
included multiple times in a single translation unit, unmatched braces
would appear after preprocessing.