### PR TITLE
Fix/no except

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -695,6 +695,13 @@ namespace SafeIntInternal
     //                                       exits the app with a crash
     template < typename E > class SafeIntExceptionHandler;
 
+#if __cpp_exceptions >= 199711L
+
+    // Some users may have applications that do not use C++ exceptions
+    // and cannot compile the following class. If that is the case,
+    // either SafeInt_InvalidParameter must be defined as the default,
+    // or a custom, user-supplied exception handler must be provided.
+
     template <> class SafeIntExceptionHandler < SafeIntException >
     {
     public:
@@ -702,15 +709,17 @@ namespace SafeIntInternal
         static SAFEINT_NORETURN void SAFEINT_STDCALL SafeIntOnOverflow()
         {
             SafeIntExceptionAssert();
-            throw SafeIntException(SafeIntError::SafeIntArithmeticOverflow );
+            throw SafeIntException( SafeIntError::SafeIntArithmeticOverflow );
         }
 
         static SAFEINT_NORETURN void SAFEINT_STDCALL SafeIntOnDivZero()
         {
             SafeIntExceptionAssert();
-            throw SafeIntException(SafeIntError::SafeIntDivideByZero );
+            throw SafeIntException( SafeIntError::SafeIntDivideByZero );
         }
     };
+
+#endif
 
    class SafeInt_InvalidParameter
    {
@@ -751,7 +760,10 @@ namespace SafeIntInternal
 } // namespace SafeIntInternal
 
 // both of these have cross-platform support
+#if __cpp_exceptions >= 199711L
 typedef SafeIntInternal::SafeIntExceptionHandler < SafeIntException > CPlusPlusExceptionHandler;
+#endif
+
 typedef SafeIntInternal::SafeInt_InvalidParameter InvalidParameterExceptionHandler;
 
 // This exception handler is no longer recommended, but is left here in order not to break existing users
@@ -780,7 +792,12 @@ typedef SafeIntInternal::SafeIntWin32ExceptionHandler Win32ExceptionHandler;
     #elif defined SAFEINT_FAILFAST
         #define SafeIntDefaultExceptionHandler InvalidParameterExceptionHandler
     #else
-        #define SafeIntDefaultExceptionHandler CPlusPlusExceptionHandler
+        #if __cpp_exceptions >= 199711L
+            #define SafeIntDefaultExceptionHandler CPlusPlusExceptionHandler
+        #else
+            #define SafeIntDefaultExceptionHandler InvalidParameterExceptionHandler
+        #endif
+
         #if !defined SAFEINT_EXCEPTION_HANDLER_CPP
         #define SAFEINT_EXCEPTION_HANDLER_CPP 1
         #endif

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -3,7 +3,7 @@
 
 /*-----------------------------------------------------------------------------------------------------------
 SafeInt.hpp
-Version 3.0.24p
+Version 3.0.25p
 
 This header implements an integer handling class designed to catch
 unsafe integer operations

--- a/Test/AddVerify.cpp
+++ b/Test/AddVerify.cpp
@@ -332,10 +332,10 @@ void AddVerifyUint64Uint64()
         std::uint64_t ret;
         if( SafeAdd(uint64_uint64[i].x, uint64_uint64[i].y, ret) != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64: ";
-            cerr << HEX(16) << uint64_uint64[i].x << ", ";
-            cerr << HEX(16) << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64: ",
+            uint64_uint64[i].x, 
+            uint64_uint64[i].y, 
+            uint64_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -352,10 +352,7 @@ void AddVerifyUint64Uint64()
 
         if( fSuccess != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64 throw (1): ";
-            cerr << HEX(16) << uint64_uint64[i].x << ", ";
-            cerr << HEX(16) << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64 throw (1): ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -373,10 +370,7 @@ void AddVerifyUint64Uint64()
 
         if( fSuccess != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64 throw (2): ";
-            cerr << HEX(16) << uint64_uint64[i].x << ", ";
-            cerr << HEX(16) << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64 throw (2): ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
         }
     }
 }
@@ -555,10 +549,7 @@ void AddVerifyUint64Uint32()
         std::uint64_t ret;
         if( SafeAdd(uint64_uint32[i].x, uint64_uint32[i].y, ret) != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32: ";
-            cerr << HEX(16) << uint64_uint32[i].x << ", ";
-            cerr << HEX(8) << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -575,10 +566,7 @@ void AddVerifyUint64Uint32()
 
         if( fSuccess != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32 throw (1): ";
-            cerr << HEX(16) << uint64_uint32[i].x << ", ";
-            cerr << HEX(8) << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32 throw (1): ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -596,10 +584,7 @@ void AddVerifyUint64Uint32()
 
         if( fSuccess != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32 throw (2): ";
-            cerr << HEX(16) << uint64_uint32[i].x << ", ";
-            cerr << HEX(8) << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32 throw (2): ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
     }
 }
@@ -778,10 +763,7 @@ void AddVerifyUint64Uint16()
         std::uint64_t ret;
         if( SafeAdd(uint64_uint16[i].x, uint64_uint16[i].y, ret) != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16: ";
-            cerr << HEX(16) << uint64_uint16[i].x << ", ";
-            cerr << HEX(4) << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16: ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -798,10 +780,7 @@ void AddVerifyUint64Uint16()
 
         if( fSuccess != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16 throw (1): ";
-            cerr << HEX(16) << uint64_uint16[i].x << ", ";
-            cerr << HEX(4) << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16 throw (1): ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -819,10 +798,7 @@ void AddVerifyUint64Uint16()
 
         if( fSuccess != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16 throw (2): ";
-            cerr << HEX(16) << uint64_uint16[i].x << ", ";
-            cerr << HEX(4) << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16 throw (2): ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
     }
 }
@@ -1001,10 +977,7 @@ void AddVerifyUint64Uint8()
         std::uint64_t ret;
         if( SafeAdd(uint64_uint8[i].x, uint64_uint8[i].y, ret) != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8: ";
-            cerr << HEX(16) << uint64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8: ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -1021,10 +994,7 @@ void AddVerifyUint64Uint8()
 
         if( fSuccess != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8 throw (1): ";
-            cerr << HEX(16) << uint64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8 throw (1): ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1042,10 +1012,7 @@ void AddVerifyUint64Uint8()
 
         if( fSuccess != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8 throw (2): ";
-            cerr << HEX(16) << uint64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8 throw (2): ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
     }
 }
@@ -1368,10 +1335,7 @@ void AddVerifyUint64Int64()
         std::uint64_t ret;
         if( SafeAdd(uint64_int64[i].x, uint64_int64[i].y, ret) != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64: ";
-            cerr << HEX(16) << uint64_int64[i].x << ", ";
-            cerr << HEX(16) << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -1388,10 +1352,7 @@ void AddVerifyUint64Int64()
 
         if( fSuccess != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64 throw (1): ";
-            cerr << HEX(16) << uint64_int64[i].x << ", ";
-            cerr << HEX(16) << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64 throw (1): ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1409,10 +1370,7 @@ void AddVerifyUint64Int64()
 
         if( fSuccess != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64 throw (2): ";
-            cerr << HEX(16) << uint64_int64[i].x << ", ";
-            cerr << HEX(16) << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64 throw (2): ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
     }
 }
@@ -1591,10 +1549,7 @@ void AddVerifyUint64Int32()
         std::uint64_t ret;
         if( SafeAdd(uint64_int32[i].x, uint64_int32[i].y, ret) != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32: ";
-            cerr << HEX(16) << uint64_int32[i].x << ", ";
-            cerr << HEX(8) << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -1611,10 +1566,7 @@ void AddVerifyUint64Int32()
 
         if( fSuccess != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32 throw (1): ";
-            cerr << HEX(16) << uint64_int32[i].x << ", ";
-            cerr << HEX(8) << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32 throw (1): ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1632,10 +1584,7 @@ void AddVerifyUint64Int32()
 
         if( fSuccess != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32 throw (2): ";
-            cerr << HEX(16) << uint64_int32[i].x << ", ";
-            cerr << HEX(8) << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32 throw (2): ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
     }
 }
@@ -1814,10 +1763,7 @@ void AddVerifyUint64Int16()
         std::uint64_t ret;
         if( SafeAdd(uint64_int16[i].x, uint64_int16[i].y, ret) != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16: ";
-            cerr << HEX(16) << uint64_int16[i].x << ", ";
-            cerr << HEX(4) << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16: ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -1834,10 +1780,7 @@ void AddVerifyUint64Int16()
 
         if( fSuccess != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16 throw (1): ";
-            cerr << HEX(16) << uint64_int16[i].x << ", ";
-            cerr << HEX(4) << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16 throw (1): ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1855,10 +1798,7 @@ void AddVerifyUint64Int16()
 
         if( fSuccess != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16 throw (2): ";
-            cerr << HEX(16) << uint64_int16[i].x << ", ";
-            cerr << HEX(4) << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16 throw (2): ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
     }
 }
@@ -2037,10 +1977,7 @@ void AddVerifyUint64Int8()
         std::uint64_t ret;
         if( SafeAdd(uint64_int8[i].x, uint64_int8[i].y, ret) != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8: ";
-            cerr << HEX(16) << uint64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8: ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -2057,10 +1994,7 @@ void AddVerifyUint64Int8()
 
         if( fSuccess != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8 throw (1): ";
-            cerr << HEX(16) << uint64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8 throw (1): ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2078,10 +2012,7 @@ void AddVerifyUint64Int8()
 
         if( fSuccess != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8 throw (2): ";
-            cerr << HEX(16) << uint64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8 throw (2): ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
     }
 }
@@ -2404,10 +2335,7 @@ void AddVerifyInt64Uint64()
         std::int64_t ret;
         if( SafeAdd(int64_uint64[i].x, int64_uint64[i].y, ret) != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64: ";
-            cerr << HEX(16) << int64_uint64[i].x << ", ";
-            cerr << HEX(16) << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -2424,10 +2352,7 @@ void AddVerifyInt64Uint64()
 
         if( fSuccess != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64 throw (1): ";
-            cerr << HEX(16) << int64_uint64[i].x << ", ";
-            cerr << HEX(16) << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64 throw (1): ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2445,10 +2370,7 @@ void AddVerifyInt64Uint64()
 
         if( fSuccess != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64 throw (2): ";
-            cerr << HEX(16) << int64_uint64[i].x << ", ";
-            cerr << HEX(16) << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64 throw (2): ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
         }
     }
 }
@@ -2627,10 +2549,7 @@ void AddVerifyInt64Uint32()
         std::int64_t ret;
         if( SafeAdd(int64_uint32[i].x, int64_uint32[i].y, ret) != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32: ";
-            cerr << HEX(16) << int64_uint32[i].x << ", ";
-            cerr << HEX(8) << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32: ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -2647,10 +2566,7 @@ void AddVerifyInt64Uint32()
 
         if( fSuccess != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32 throw (1): ";
-            cerr << HEX(16) << int64_uint32[i].x << ", ";
-            cerr << HEX(8) << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32 throw (1): ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2668,10 +2584,7 @@ void AddVerifyInt64Uint32()
 
         if( fSuccess != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32 throw (2): ";
-            cerr << HEX(16) << int64_uint32[i].x << ", ";
-            cerr << HEX(8) << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32 throw (2): ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
     }
 }
@@ -2850,10 +2763,7 @@ void AddVerifyInt64Uint16()
         std::int64_t ret;
         if( SafeAdd(int64_uint16[i].x, int64_uint16[i].y, ret) != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16: ";
-            cerr << HEX(16) << int64_uint16[i].x << ", ";
-            cerr << HEX(4) << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16: ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -2870,10 +2780,7 @@ void AddVerifyInt64Uint16()
 
         if( fSuccess != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16 throw (1): ";
-            cerr << HEX(16) << int64_uint16[i].x << ", ";
-            cerr << HEX(4) << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16 throw (1): ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2891,10 +2798,7 @@ void AddVerifyInt64Uint16()
 
         if( fSuccess != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16 throw (2): ";
-            cerr << HEX(16) << int64_uint16[i].x << ", ";
-            cerr << HEX(4) << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16 throw (2): ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
     }
 }
@@ -3073,10 +2977,7 @@ void AddVerifyInt64Uint8()
         std::int64_t ret;
         if( SafeAdd(int64_uint8[i].x, int64_uint8[i].y, ret) != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8: ";
-            cerr << HEX(16) << int64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8: ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -3093,10 +2994,7 @@ void AddVerifyInt64Uint8()
 
         if( fSuccess != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8 throw (1): ";
-            cerr << HEX(16) << int64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8 throw (1): ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3114,10 +3012,7 @@ void AddVerifyInt64Uint8()
 
         if( fSuccess != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8 throw (2): ";
-            cerr << HEX(16) << int64_uint8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8 throw (2): ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
     }
 }
@@ -3440,10 +3335,7 @@ void AddVerifyInt64Int64()
         std::int64_t ret;
         if( SafeAdd(int64_int64[i].x, int64_int64[i].y, ret) != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64: ";
-            cerr << HEX(16) << int64_int64[i].x << ", ";
-            cerr << HEX(16) << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -3460,10 +3352,7 @@ void AddVerifyInt64Int64()
 
         if( fSuccess != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64 throw (1): ";
-            cerr << HEX(16) << int64_int64[i].x << ", ";
-            cerr << HEX(16) << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64 throw (1): ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3481,10 +3370,7 @@ void AddVerifyInt64Int64()
 
         if( fSuccess != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64 throw (2): ";
-            cerr << HEX(16) << int64_int64[i].x << ", ";
-            cerr << HEX(16) << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64 throw (2): ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
     }
 }
@@ -3663,10 +3549,7 @@ void AddVerifyInt64Int32()
         std::int64_t ret;
         if( SafeAdd(int64_int32[i].x, int64_int32[i].y, ret) != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32: ";
-            cerr << HEX(16) << int64_int32[i].x << ", ";
-            cerr << HEX(8) << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32: ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -3683,10 +3566,7 @@ void AddVerifyInt64Int32()
 
         if( fSuccess != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32 throw (1): ";
-            cerr << HEX(16) << int64_int32[i].x << ", ";
-            cerr << HEX(8) << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32 throw (1): ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3704,10 +3584,7 @@ void AddVerifyInt64Int32()
 
         if( fSuccess != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32 throw (2): ";
-            cerr << HEX(16) << int64_int32[i].x << ", ";
-            cerr << HEX(8) << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32 throw (2): ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
     }
 }
@@ -3886,10 +3763,7 @@ void AddVerifyInt64Int16()
         std::int64_t ret;
         if( SafeAdd(int64_int16[i].x, int64_int16[i].y, ret) != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16: ";
-            cerr << HEX(16) << int64_int16[i].x << ", ";
-            cerr << HEX(4) << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16: ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -3906,10 +3780,7 @@ void AddVerifyInt64Int16()
 
         if( fSuccess != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16 throw (1): ";
-            cerr << HEX(16) << int64_int16[i].x << ", ";
-            cerr << HEX(4) << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16 throw (1): ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3927,10 +3798,7 @@ void AddVerifyInt64Int16()
 
         if( fSuccess != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16 throw (2): ";
-            cerr << HEX(16) << int64_int16[i].x << ", ";
-            cerr << HEX(4) << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16 throw (2): ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
     }
 }
@@ -4109,10 +3977,7 @@ void AddVerifyInt64Int8()
         std::int64_t ret;
         if( SafeAdd(int64_int8[i].x, int64_int8[i].y, ret) != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8: ";
-            cerr << HEX(16) << int64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8: ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -4129,10 +3994,7 @@ void AddVerifyInt64Int8()
 
         if( fSuccess != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8 throw (1): ";
-            cerr << HEX(16) << int64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8 throw (1): ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4150,10 +4012,7 @@ void AddVerifyInt64Int8()
 
         if( fSuccess != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8 throw (2): ";
-            cerr << HEX(16) << int64_int8[i].x << ", ";
-            cerr << HEX(2) << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8 throw (2): ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
     }
 }
@@ -4340,10 +4199,7 @@ void AddVerifyUint8Uint64()
         std::uint8_t ret;
         if( SafeAdd(uint8_uint64[i].x, uint8_uint64[i].y, ret) != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint64[i].x) << ", ";
-            cerr << HEX(16) << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64: ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -4360,10 +4216,7 @@ void AddVerifyUint8Uint64()
 
         if( fSuccess != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint64[i].x) << ", ";
-            cerr << HEX(16) << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64 throw (1): ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4381,10 +4234,7 @@ void AddVerifyUint8Uint64()
 
         if( fSuccess != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint64[i].x) << ", ";
-            cerr << HEX(16) << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64 throw (2): ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
     }
 }
@@ -4491,10 +4341,7 @@ void AddVerifyUint8Uint32()
         std::uint8_t ret;
         if( SafeAdd(uint8_uint32[i].x, uint8_uint32[i].y, ret) != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint32[i].x) << ", ";
-            cerr << HEX(8) << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32: ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -4511,10 +4358,7 @@ void AddVerifyUint8Uint32()
 
         if( fSuccess != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint32[i].x) << ", ";
-            cerr << HEX(8) << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32 throw (1): ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4532,10 +4376,7 @@ void AddVerifyUint8Uint32()
 
         if( fSuccess != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint32[i].x) << ", ";
-            cerr << HEX(8) << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32 throw (2): ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
     }
 }
@@ -4642,10 +4483,7 @@ void AddVerifyUint8Uint16()
         std::uint8_t ret;
         if( SafeAdd(uint8_uint16[i].x, uint8_uint16[i].y, ret) != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint16[i].x) << ", ";
-            cerr << HEX(4) << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16: ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -4662,10 +4500,7 @@ void AddVerifyUint8Uint16()
 
         if( fSuccess != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint16[i].x) << ", ";
-            cerr << HEX(4) << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16 throw (1): ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4683,10 +4518,7 @@ void AddVerifyUint8Uint16()
 
         if( fSuccess != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint16[i].x) << ", ";
-            cerr << HEX(4) << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16 throw (2): ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
     }
 }
@@ -4793,10 +4625,7 @@ void AddVerifyUint8Uint8()
         std::uint8_t ret;
         if( SafeAdd(uint8_uint8[i].x, uint8_uint8[i].y, ret) != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8: ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -4813,10 +4642,7 @@ void AddVerifyUint8Uint8()
 
         if( fSuccess != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8 throw (1): ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4834,10 +4660,7 @@ void AddVerifyUint8Uint8()
 
         if( fSuccess != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8 throw (2): ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
     }
 }
@@ -5024,10 +4847,7 @@ void AddVerifyUint8Int64()
         std::uint8_t ret;
         if( SafeAdd(uint8_int64[i].x, uint8_int64[i].y, ret) != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int64[i].x) << ", ";
-            cerr << HEX(16) << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64: ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -5044,10 +4864,7 @@ void AddVerifyUint8Int64()
 
         if( fSuccess != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int64[i].x) << ", ";
-            cerr << HEX(16) << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64 throw (1): ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5065,10 +4882,7 @@ void AddVerifyUint8Int64()
 
         if( fSuccess != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int64[i].x) << ", ";
-            cerr << HEX(16) << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64 throw (2): ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
     }
 }
@@ -5175,10 +4989,7 @@ void AddVerifyUint8Int32()
         std::uint8_t ret;
         if( SafeAdd(uint8_int32[i].x, uint8_int32[i].y, ret) != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int32[i].x) << ", ";
-            cerr << HEX(8) << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32: ", uint8_int32[i].x, uint8_int32[i].y, uint8_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -5195,10 +5006,7 @@ void AddVerifyUint8Int32()
 
         if( fSuccess != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int32[i].x) << ", ";
-            cerr << HEX(8) << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32 throw (1): ", uint8_int32[i].x, uint8_int32[i].y, uint8_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5216,10 +5024,7 @@ void AddVerifyUint8Int32()
 
         if( fSuccess != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int32[i].x) << ", ";
-            cerr << HEX(8) << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32 throw (2): ", uint8_int32[i].x, uint8_int32[i].y, uint8_int32[i].fExpected );
         }
     }
 }
@@ -5326,10 +5131,7 @@ void AddVerifyUint8Int16()
         std::uint8_t ret;
         if( SafeAdd(uint8_int16[i].x, uint8_int16[i].y, ret) != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int16[i].x) << ", ";
-            cerr << HEX(4) << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16: ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -5346,10 +5148,7 @@ void AddVerifyUint8Int16()
 
         if( fSuccess != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int16[i].x) << ", ";
-            cerr << HEX(4) << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16 throw (1): ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5367,10 +5166,7 @@ void AddVerifyUint8Int16()
 
         if( fSuccess != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int16[i].x) << ", ";
-            cerr << HEX(4) << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16 throw (2): ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
     }
 }
@@ -5477,10 +5273,7 @@ void AddVerifyUint8Int8()
         std::uint8_t ret;
         if( SafeAdd(uint8_int8[i].x, uint8_int8[i].y, ret) != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8: ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8: ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -5497,10 +5290,7 @@ void AddVerifyUint8Int8()
 
         if( fSuccess != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8 throw (1): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8 throw (1): ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5518,10 +5308,7 @@ void AddVerifyUint8Int8()
 
         if( fSuccess != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8 throw (2): ";
-            cerr << HEX(2) << (0xFF & (unsigned int)uint8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8 throw (2): ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
     }
 }
@@ -5708,10 +5495,7 @@ void AddVerifyInt8Uint64()
         std::int8_t ret;
         if( SafeAdd(int8_uint64[i].x, int8_uint64[i].y, ret) != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64: ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << HEX(16) << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64: ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -5728,10 +5512,7 @@ void AddVerifyInt8Uint64()
 
         if( fSuccess != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << HEX(16) << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64 throw (1): ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5749,10 +5530,7 @@ void AddVerifyInt8Uint64()
 
         if( fSuccess != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << HEX(16) << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64 throw (2): ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
     }
 }
@@ -5859,10 +5637,7 @@ void AddVerifyInt8Uint32()
         std::int8_t ret;
         if( SafeAdd(int8_uint32[i].x, int8_uint32[i].y, ret) != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32: ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << HEX(8) << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32: ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -5879,10 +5654,7 @@ void AddVerifyInt8Uint32()
 
         if( fSuccess != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << HEX(8) << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32 throw (1): ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5900,10 +5672,7 @@ void AddVerifyInt8Uint32()
 
         if( fSuccess != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << HEX(8) << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32 throw (2): ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
     }
 }
@@ -6010,10 +5779,7 @@ void AddVerifyInt8Uint16()
         std::int8_t ret;
         if( SafeAdd(int8_uint16[i].x, int8_uint16[i].y, ret) != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16: ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << HEX(4) << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16: ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -6030,10 +5796,7 @@ void AddVerifyInt8Uint16()
 
         if( fSuccess != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << HEX(4) << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16 throw (1): ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6051,10 +5814,7 @@ void AddVerifyInt8Uint16()
 
         if( fSuccess != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << HEX(4) << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16 throw (2): ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
     }
 }
@@ -6161,10 +5921,7 @@ void AddVerifyInt8Uint8()
         std::int8_t ret;
         if( SafeAdd(int8_uint8[i].x, int8_uint8[i].y, ret) != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8: ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8: ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -6181,10 +5938,7 @@ void AddVerifyInt8Uint8()
 
         if( fSuccess != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8 throw (1): ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6202,10 +5956,7 @@ void AddVerifyInt8Uint8()
 
         if( fSuccess != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8 throw (2): ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
     }
 }
@@ -6392,10 +6143,7 @@ void AddVerifyInt8Int64()
         std::int8_t ret;
         if( SafeAdd(int8_int64[i].x, int8_int64[i].y, ret) != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64: ";
-            cerr << HEX(2) << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << HEX(16) << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64: ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -6412,10 +6160,7 @@ void AddVerifyInt8Int64()
 
         if( fSuccess != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << HEX(16) << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64 throw (1): ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6433,10 +6178,7 @@ void AddVerifyInt8Int64()
 
         if( fSuccess != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << HEX(16) << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64 throw (2): ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
     }
 }
@@ -6543,10 +6285,7 @@ void AddVerifyInt8Int32()
         std::int8_t ret;
         if( SafeAdd(int8_int32[i].x, int8_int32[i].y, ret) != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32: ";
-            cerr << HEX(2) << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << HEX(8) << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32: ", int8_int32[i].x, int8_int32[i].y, int8_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -6563,10 +6302,7 @@ void AddVerifyInt8Int32()
 
         if( fSuccess != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << HEX(8) << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32 throw (1): ", int8_int32[i].x, int8_int32[i].y, int8_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6584,10 +6320,7 @@ void AddVerifyInt8Int32()
 
         if( fSuccess != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << HEX(8) << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32 throw (2): ", int8_int32[i].x, int8_int32[i].y, int8_int32[i].fExpected );
         }
     }
 }
@@ -6694,10 +6427,7 @@ void AddVerifyInt8Int16()
         std::int8_t ret;
         if( SafeAdd(int8_int16[i].x, int8_int16[i].y, ret) != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16: ";
-            cerr << HEX(2) << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << HEX(4) << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16: ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -6714,10 +6444,7 @@ void AddVerifyInt8Int16()
 
         if( fSuccess != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << HEX(4) << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16 throw (1): ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6735,10 +6462,7 @@ void AddVerifyInt8Int16()
 
         if( fSuccess != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << HEX(4) << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16 throw (2): ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
     }
 }
@@ -6845,10 +6569,7 @@ void AddVerifyInt8Int8()
         std::int8_t ret;
         if( SafeAdd(int8_int8[i].x, int8_int8[i].y, ret) != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8: ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8: ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -6865,10 +6586,7 @@ void AddVerifyInt8Int8()
 
         if( fSuccess != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8 throw (1): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8 throw (1): ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6886,17 +6604,14 @@ void AddVerifyInt8Int8()
 
         if( fSuccess != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8 throw (2): ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << HEX(2) << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8 throw (2): ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
     }
 }
 
 void AddVerify()
 {
-    cout << "Verifying Addition:" << endl;
+    std::cout << "Verifying Addition:" << std::endl;
 
     // Unsigned int64, unsigned cases
     AddVerifyUint64Uint64();

--- a/Test/CastVerify.cpp
+++ b/Test/CastVerify.cpp
@@ -74,7 +74,7 @@ namespace cast_verify
 			}
 
 			if(fSuccess != tests[i].fExpected)
-				cerr << "Error in cast double to std::uint64_t case " << i << endl;
+				std::cerr << "Error in cast double to std::uint64_t case " << i << std::endl;
 		}
 	}
 
@@ -100,13 +100,13 @@ namespace cast_verify
 			}
 
 			if (fSuccess != tests[i].fExpected)
-				cerr << "Error in cast float to std::uint64_t case " << i << endl;
+				std::cerr << "Error in cast float to std::uint64_t case " << i << std::endl;
 		}
 	}
 
 	void CastVerify()
 	{
-		cout << "Verifying Casting:" << endl;
+		std::cout << "Verifying Casting:" << std::endl;
 		TestDouble();
 	}
 }

--- a/Test/ClangTest/makefile
+++ b/Test/ClangTest/makefile
@@ -16,3 +16,6 @@ CompileTest: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompi
 
 CompileTest14: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	clang++ -Wall --std=c++14 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest14 2> CompileTest14.err
+
+CompileTest14_NoEH: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
+	clang++ -fno-exceptions -Wall --std=c++14 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest14 2> CompileTest14_NoEH.err

--- a/Test/DivVerify.cpp
+++ b/Test/DivVerify.cpp
@@ -161,7 +161,7 @@ void DivVerifyUint64Uint64()
       if( SafeDivide(uint64_uint64[i].x, uint64_uint64[i].y, ret) != uint64_uint64[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_uint64: %I64X, %I64X, expected = %s\n", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint64: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
       }
 
       // Now test throwing version
@@ -178,7 +178,7 @@ void DivVerifyUint64Uint64()
 
       if( fSuccess != uint64_uint64[i].fExpected )
       {
-         printf("Error in case uint64_uint64 throw: %I64X, %I64X, expected = %s\n", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint64 throw: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -196,7 +196,7 @@ void DivVerifyUint64Uint64()
 
       if( fSuccess != uint64_uint64[i].fExpected )
       {
-         printf("Error in case uint64_uint64 throw: %I64X, %I64X, expected = %s\n", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint64 throw: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
       }
    }
 }
@@ -281,7 +281,7 @@ void DivVerifyUint64Uint32()
       if( SafeDivide(uint64_uint32[i].x, uint64_uint32[i].y, ret) != uint64_uint32[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_uint32: %I64X, %X, expected = %s\n", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected ? "true" : "false");
+         err_msg( "Error in case uint64_uint32: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
       }
 
       // Now test throwing version
@@ -298,7 +298,7 @@ void DivVerifyUint64Uint32()
 
       if( fSuccess != uint64_uint32[i].fExpected )
       {
-         printf("Error in case uint64_uint32 throw: %I64X, %X, expected = %s\n", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint32 throw: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -316,7 +316,7 @@ void DivVerifyUint64Uint32()
 
       if( fSuccess != uint64_uint32[i].fExpected )
       {
-         printf("Error in case uint64_uint32 throw: %I64X, %X, expected = %s\n", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint32 throw: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
       }
    }
 }
@@ -368,7 +368,7 @@ void DivVerifyUint64Uint16()
       if( SafeDivide(uint64_uint16[i].x, uint64_uint16[i].y, ret) != uint64_uint16[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_uint16: %I64X, %X, expected = %s\n", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint16: ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
       }
 
       // Now test throwing version
@@ -385,7 +385,7 @@ void DivVerifyUint64Uint16()
 
       if( fSuccess != uint64_uint16[i].fExpected )
       {
-         printf("Error in case uint64_uint16 throw: %I64X, %X, expected = %s\n", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint16 throw: ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -403,7 +403,7 @@ void DivVerifyUint64Uint16()
 
       if( fSuccess != uint64_uint16[i].fExpected )
       {
-         printf("Error in case uint64_uint16 throw: %I64X, %X, expected = %s\n", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint16 throw: ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
       }
    }
 }
@@ -455,7 +455,7 @@ void DivVerifyUint64Uint8()
       if( SafeDivide(uint64_uint8[i].x, uint64_uint8[i].y, ret) != uint64_uint8[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_uint8: %I64X, %X, expected = %s\n", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint8: ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
       }
 
       // Now test throwing version
@@ -472,7 +472,7 @@ void DivVerifyUint64Uint8()
 
       if( fSuccess != uint64_uint8[i].fExpected )
       {
-         printf("Error in case uint64_uint8 throw: %I64X, %X, expected = %s\n", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint8 throw: ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -490,7 +490,7 @@ void DivVerifyUint64Uint8()
 
       if( fSuccess != uint64_uint8[i].fExpected )
       {
-         printf("Error in case uint64_uint8 throw: %I64X, %X, expected = %s\n", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_uint8 throw: ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
       }
    }
 }
@@ -633,7 +633,7 @@ void DivVerifyUint64Int64()
       if( SafeDivide(uint64_int64[i].x, uint64_int64[i].y, ret) != uint64_int64[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_int64: %I64X, %I64X, expected = %s\n", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
       }
 
       // Now test throwing version
@@ -650,7 +650,7 @@ void DivVerifyUint64Int64()
 
       if( fSuccess != uint64_int64[i].fExpected )
       {
-         printf("Error in case uint64_int64 throw: %I64X, %I64X, expected = %s\n", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64 throw: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -668,7 +668,7 @@ void DivVerifyUint64Int64()
 
       if( fSuccess != uint64_int64[i].fExpected )
       {
-         printf("Error in case uint64_int64 throw: %I64X, %I64X, expected = %s\n", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64 throw: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
       }
    }
 }
@@ -820,7 +820,7 @@ void DivVerifyUint64Int64_2()
 
       if( fSuccess != int64_uint64_2[i].fExpected )
       {
-         printf("Error in case int64_uint64_2 throw: %I64X, %I64X, expected = %s\n", int64_uint64_2[i].x, int64_uint64_2[i].y, int64_uint64_2[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_uint64_2 throw: ", int64_uint64_2[i].x, int64_uint64_2[i].y, int64_uint64_2[i].fExpected );
       }
    }
 }
@@ -905,7 +905,7 @@ void DivVerifyUint64Int32()
       if( SafeDivide(uint64_int32[i].x, uint64_int32[i].y, ret) != uint64_int32[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_int64: %I64X, %I64X, expected = %s\n", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
       }
 
       // Now test throwing version
@@ -922,7 +922,7 @@ void DivVerifyUint64Int32()
 
       if( fSuccess != uint64_int32[i].fExpected )
       {
-         printf("Error in case uint64_int32 throw: %I64X, %X, expected = %s\n", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int32 throw: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -940,7 +940,7 @@ void DivVerifyUint64Int32()
 
       if( fSuccess != uint64_int32[i].fExpected )
       {
-         printf("Error in case uint64_int64 throw: %I64X, %X, expected = %s\n", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64 throw: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
       }
    }
 }
@@ -1037,7 +1037,7 @@ void DivVerifyUint64Int32_2()
 
       if( fSuccess != int32_uint64_2[i].fExpected )
       {
-         printf("Error in case int32_uint64_2 throw: %X, %I64X, expected = %s\n", int32_uint64_2[i].x, int32_uint64_2[i].y, int32_uint64_2[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int32_uint64_2 throw: ", int32_uint64_2[i].x, int32_uint64_2[i].y, int32_uint64_2[i].fExpected );
       }
    }
 }
@@ -1100,7 +1100,7 @@ void DivVerifyUint64Int16()
       if( SafeDivide(uint64_int16[i].x, uint64_int16[i].y, ret) != uint64_int16[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_int64: %I64X, %I64X, expected = %s\n", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64: ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
       }
 
       // Now test throwing version
@@ -1117,7 +1117,7 @@ void DivVerifyUint64Int16()
 
       if( fSuccess != uint64_int16[i].fExpected )
       {
-         printf("Error in case uint64_int32 throw: %I64X, %X, expected = %s\n", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int32 throw: ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -1135,7 +1135,7 @@ void DivVerifyUint64Int16()
 
       if( fSuccess != uint64_int16[i].fExpected )
       {
-         printf("Error in case uint64_int16 throw: %I64X, %X, expected = %s\n", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int16 throw: ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
       }
    }
 }
@@ -1232,7 +1232,7 @@ void DivVerifyUint64Int16_2()
 
       if( fSuccess != int16_uint64_2[i].fExpected )
       {
-         printf("Error in case int16_uint64_2 throw: %X, %I64X, expected = %s\n", int16_uint64_2[i].x, int16_uint64_2[i].y, int16_uint64_2[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int16_uint64_2 throw: ", int16_uint64_2[i].x, int16_uint64_2[i].y, int16_uint64_2[i].fExpected );
       }
    }
 }
@@ -1295,7 +1295,7 @@ void DivVerifyUint64Int8()
       if( SafeDivide(uint64_int8[i].x, uint64_int8[i].y, ret) != uint64_int8[i].fExpected )
       {
          //assert(false);
-         printf("Error in case uint64_int64: %I64X, %I64X, expected = %s\n", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int64: ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
       }
 
       // Now test throwing version
@@ -1312,7 +1312,7 @@ void DivVerifyUint64Int8()
 
       if( fSuccess != uint64_int8[i].fExpected )
       {
-         printf("Error in case uint64_int32 throw: %I64X, %X, expected = %s\n", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int32 throw: ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -1330,7 +1330,7 @@ void DivVerifyUint64Int8()
 
       if( fSuccess != uint64_int8[i].fExpected )
       {
-         printf("Error in case uint64_int8 throw: %I64X, %X, expected = %s\n", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected ? "true" : "false");
+          err_msg( "Error in case uint64_int8 throw: ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
       }
    }
 }
@@ -1427,7 +1427,7 @@ void DivVerifyUint64Int8_2()
 
       if( fSuccess != int8_uint64_2[i].fExpected )
       {
-         printf("Error in case int8_uint64_2 throw: %X, %I64X, expected = %s\n", int8_uint64_2[i].x, int8_uint64_2[i].y, int8_uint64_2[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int8_uint64_2 throw: ", int8_uint64_2[i].x, int8_uint64_2[i].y, int8_uint64_2[i].fExpected );
       }
    }
 }
@@ -1567,7 +1567,7 @@ void DivVerifyInt64Int64()
       if( SafeDivide(int64_int64[i].x, int64_int64[i].y, ret) != int64_int64[i].fExpected )
       {
          //assert(false);
-         printf("Error in case int64_int64: %I64X, %I64X, expected = %s\n", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int64: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
       }
 
       // Now test throwing version
@@ -1584,7 +1584,7 @@ void DivVerifyInt64Int64()
 
       if( fSuccess != int64_int64[i].fExpected )
       {
-         printf("Error in case int64_int64 throw: %I64X, %I64X, expected = %s\n", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_int64 throw: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -1602,7 +1602,7 @@ void DivVerifyInt64Int64()
 
       if( fSuccess != int64_int64[i].fExpected )
       {
-         printf("Error in case int64_int64 throw: %I64X, %I64X, expected = %s\n", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int64 throw: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
       }
    }
 }
@@ -1629,7 +1629,7 @@ void DivVerifyInt64Int64_2()
 
       if( fSuccess != int64_int64[i].fExpected )
       {
-         printf("Error in case int64_int64 throw: %X, %I64X, expected = %s\n", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int64 throw: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
       }
    }
 }
@@ -1714,7 +1714,7 @@ void DivVerifyInt64Int32()
       if( SafeDivide(int64_int32[i].x, int64_int32[i].y, ret) != int64_int32[i].fExpected )
       {
          //assert(false);
-         printf("Error in case int64_int32: %I64X, %I64X, expected = %s\n", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int32: ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
       }
 
       // Now test throwing version
@@ -1731,7 +1731,7 @@ void DivVerifyInt64Int32()
 
       if( fSuccess != int64_int32[i].fExpected )
       {
-         printf("Error in case int64_int32 throw: %I64X, %I64X, expected = %s\n", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int32 throw: ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -1749,7 +1749,7 @@ void DivVerifyInt64Int32()
 
       if( fSuccess != int64_int32[i].fExpected )
       {
-         printf("Error in case int64_int32 throw: %I64X, %I64X, expected = %s\n", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int32 throw: ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
       }
    }
 }
@@ -1846,7 +1846,7 @@ void DivVerifyInt64Int32_2()
 
       if( fSuccess != int64_int32_2[i].fExpected )
       {
-         printf("Error in case int64_int32_2 throw: %X, %I64X, expected = %s\n", int64_int32_2[i].x, int64_int32_2[i].y, int64_int32_2[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_int32_2 throw: ", int64_int32_2[i].x, int64_int32_2[i].y, int64_int32_2[i].fExpected );
       }
    }
 }
@@ -1986,7 +1986,7 @@ void DivVerifyInt64Uint64()
       if( SafeDivide(int64_uint64[i].x, int64_uint64[i].y, ret) != int64_uint64[i].fExpected )
       {
          //assert(false);
-         printf("Error in case int64_uint64: %I64X, %I64X, expected = %s\n", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_uint64: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
       }
 
       // Now test throwing version
@@ -2003,7 +2003,7 @@ void DivVerifyInt64Uint64()
 
       if( fSuccess != int64_uint64[i].fExpected )
       {
-         printf("Error in case int64_uint64 throw: %I64X, %I64X, expected = %s\n", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ? "true" : "false");
+          err_msg( "Error in case int64_uint64 throw: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -2021,7 +2021,7 @@ void DivVerifyInt64Uint64()
 
       if( fSuccess != int64_uint64[i].fExpected )
       {
-         printf("Error in case int64_uint64 throw: %I64X, %I64X, expected = %s\n", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint64 throw: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
       }
    }
 }
@@ -2173,7 +2173,7 @@ void DivVerifyInt64Uint64_2()
 
       if( fSuccess != int64_uint64_3[i].fExpected )
       {
-         printf("Error in case int64_uint64_3 throw: %X, %I64X, expected = %s\n", int64_uint64_3[i].x, int64_uint64_3[i].y, int64_uint64_3[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint64_3 throw: ", int64_uint64_3[i].x, int64_uint64_3[i].y, int64_uint64_3[i].fExpected );
       }
    }
 }
@@ -2258,7 +2258,7 @@ void DivVerifyInt64Uint32()
       if( SafeDivide(int64_uint32[i].x, int64_uint32[i].y, ret) != int64_uint32[i].fExpected )
       {
          //assert(false);
-         printf("Error in case int64_uint32: %I64X, %I64X, expected = %s\n", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint32: ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
       }
 
       // Now test throwing version
@@ -2275,7 +2275,7 @@ void DivVerifyInt64Uint32()
 
       if( fSuccess != int64_uint32[i].fExpected )
       {
-         printf("Error in case int64_uint32 throw: %I64X, %I64X, expected = %s\n", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint32 throw: ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
       }
 
       // Also need to test the version that assigns back out
@@ -2293,7 +2293,7 @@ void DivVerifyInt64Uint32()
 
       if( fSuccess != int64_uint32[i].fExpected )
       {
-         printf("Error in case int64_uint32 throw: %I64X, %I64X, expected = %s\n", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint32 throw: ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
       }
    }
 }
@@ -2390,14 +2390,14 @@ void DivVerifyInt64Uint32_2()
 
       if( fSuccess != int64_uint32_2[i].fExpected )
       {
-         printf("Error in case int64_uint32_2 throw: %X, %I64X, expected = %s\n", int64_uint32_2[i].x, int64_uint32_2[i].y, int64_uint32_2[i].fExpected ? "true" : "false");
+         err_msg( "Error in case int64_uint32_2 throw: ", int64_uint32_2[i].x, int64_uint32_2[i].y, int64_uint32_2[i].fExpected );
       }
    }
 }
 
 void DivVerify()
 {
-   printf( "Verifying Division:\n" );
+    std::cout << "Verifying Division:" << std::endl;
 
    // Unsigned int64, unsigned cases
    DivVerifyUint64Uint64();

--- a/Test/GccTest/makefile
+++ b/Test/GccTest/makefile
@@ -18,3 +18,5 @@ CompileTest: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompi
 CompileTest14: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	g++ -Wall --std=c++14 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest14 2> CompileTest14.err
 
+CompileTest14_NoEH: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
+	g++ -fno-exceptions -Wall --std=c++14 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest14 2> CompileTest14_noEH.err

--- a/Test/IncDecVerify.cpp
+++ b/Test/IncDecVerify.cpp
@@ -59,9 +59,7 @@ void PreIncTestUint8()
 
 		if( fSuccess != inc_uint8[i].fExpected )
 		{
-			cerr << "Error in case inc_uint8 throw (1): ";
-			cerr << HEX(2) << (0xFF & (int)inc_uint8[i].x) << ", ";
-			cerr << "expected = " << inc_uint8[i].fExpected << endl;
+			err_msg( "Error in case inc_uint8 throw (1): ", inc_uint8[i].x, inc_uint8[i].fExpected );
 		}
 	}
 }
@@ -90,9 +88,7 @@ void PostIncTestUint8()
 
 		if( fSuccess != inc_uint8[i].fExpected )
 		{
-			cerr << "Error in case inc_uint8 throw (2): ";
-			cerr << HEX(2) << (0xFF & (int)inc_uint8[i].x) << ", ";
-			cerr << "expected = " << inc_uint8[i].fExpected << endl;
+			err_msg( "Error in case inc_uint8 throw (2): ", inc_uint8[i].x, inc_uint8[i].fExpected );
 		}
 	}
 }
@@ -134,9 +130,7 @@ void PreIncTestUint16()
 
 		if( fSuccess != inc_uint16[i].fExpected )
 		{
-			cerr << "Error in case inc_uint16 throw (1): ";
-			cerr << HEX(4) << inc_uint16[i].x << ", ";
-			cerr << "expected = " << inc_uint16[i].fExpected << endl;
+			err_msg( "Error in case inc_uint16 throw (1): ", inc_uint16[i].x, inc_uint16[i].fExpected );
 		}
 	}
 }
@@ -165,9 +159,7 @@ void PostIncTestUint16()
 
 		if( fSuccess != inc_uint16[i].fExpected )
 		{
-			cerr << "Error in case inc_uint16 throw (2): ";
-			cerr << HEX(4) << inc_uint16[i].x << ", ";
-			cerr << "expected = " << inc_uint16[i].fExpected << endl;
+			err_msg( "Error in case inc_uint16 throw (2): ", inc_uint16[i].x, inc_uint16[i].fExpected );
 		}
 	}
 }
@@ -209,9 +201,7 @@ void PreIncTestUint32()
 
 		if( fSuccess != inc_uint32[i].fExpected )
 		{
-			cerr << "Error in case inc_uint32 throw (1): ";
-			cerr << HEX(8) << inc_uint32[i].x << ", ";
-			cerr << "expected = " << inc_uint32[i].fExpected << endl;
+			err_msg( "Error in case inc_uint32 throw (1): ", inc_uint32[i].x, inc_uint32[i].fExpected );
 		}
 	}
 }
@@ -240,9 +230,7 @@ void PostIncTestUint32()
 
 		if( fSuccess != inc_uint32[i].fExpected )
 		{
-			cerr << "Error in case inc_uint32 throw (2): ";
-			cerr << HEX(8) << inc_uint32[i].x << ", ";
-			cerr << "expected = " << inc_uint32[i].fExpected << endl;
+			err_msg( "Error in case inc_uint32 throw (2): ", inc_uint32[i].x, inc_uint32[i].fExpected );
 		}
 	}
 }
@@ -292,9 +280,9 @@ void PreIncTestUint64()
 
 		if( fSuccess != inc_uint64[i].fExpected )
 		{
-			cerr << "Error in case inc_uint64 throw (1): ";
-			cerr << HEX(16) << inc_uint64[i].x << ", ";
-			cerr << "expected = " << inc_uint64[i].fExpected << endl;
+			err_msg( "Error in case inc_uint64 throw (1): ",
+			inc_uint64[i].x,
+			inc_uint64[i].fExpected );
 		}
 	}
 }
@@ -323,9 +311,9 @@ void PostIncTestUint64()
 
 		if( fSuccess != inc_uint64[i].fExpected )
 		{
-			cerr << "Error in case inc_uint64 throw (2): ";
-			cerr << HEX(16) << inc_uint64[i].x << ", ";
-			cerr << "expected = " << inc_uint64[i].fExpected << endl;
+			err_msg( "Error in case inc_uint64 throw (2): ",
+			inc_uint64[i].x,
+			inc_uint64[i].fExpected );
 		}
 	}
 }
@@ -367,9 +355,7 @@ void PreIncTestInt8()
 
 		if( fSuccess != inc_int8[i].fExpected )
 		{
-			cerr << "Error in case inc_int8 throw (1): ";
-			cerr << HEX(2) << (0xFF & (int)inc_int8[i].x) << ", ";
-			cerr << "expected = " << inc_int8[i].fExpected << endl;
+			err_msg( "Error in case inc_int8 throw (1): ", inc_int8[i].x, inc_int8[i].fExpected );
 		}
 	}
 }
@@ -398,9 +384,7 @@ void PostIncTestInt8()
 
 		if( fSuccess != inc_int8[i].fExpected )
 		{
-			cerr << "Error in case inc_int8 throw (2): ";
-			cerr << HEX(2) << (0xFF & (int)inc_int8[i].x) << ", ";
-			cerr << "expected = " << inc_int8[i].fExpected << endl;
+			err_msg( "Error in case inc_int8 throw (2): ", inc_int8[i].x, inc_int8[i].fExpected );
 		}
 	}
 }
@@ -442,9 +426,7 @@ void PreIncTestInt16()
 
 		if( fSuccess != inc_int16[i].fExpected )
 		{
-			cerr << "Error in case inc_int16 throw (1): ";
-			cerr << HEX(4) << inc_int16[i].x << ", ";
-			cerr << "expected = " << inc_int16[i].fExpected << endl;
+			err_msg( "Error in case inc_int16 throw (1): ", inc_int16[i].x, inc_int16[i].fExpected );
 		}
 	}
 }
@@ -473,9 +455,7 @@ void PostIncTestInt16()
 
 		if( fSuccess != inc_int16[i].fExpected )
 		{
-			cerr << "Error in case inc_int16 throw (2): ";
-			cerr << HEX(4) << inc_int16[i].x << ", ";
-			cerr << "expected = " << inc_int16[i].fExpected << endl;
+			err_msg( "Error in case inc_int16 throw (2): ", inc_int16[i].x, inc_int16[i].fExpected );
 		}
 	}
 }
@@ -517,9 +497,7 @@ void PreIncTestInt32()
 
 		if( fSuccess != inc_int32[i].fExpected )
 		{
-			cerr << "Error in case inc_int32 throw (1): ";
-			cerr << HEX(8) << inc_int32[i].x << ", ";
-			cerr << "expected = " << inc_int32[i].fExpected << endl;
+			err_msg( "Error in case inc_int32 throw (1): ", inc_int32[i].x, inc_int32[i].fExpected );
 		}
 	}
 }
@@ -548,9 +526,7 @@ void PostIncTestInt32()
 
 		if( fSuccess != inc_int32[i].fExpected )
 		{
-			cerr << "Error in case inc_int32 throw (2): ";
-			cerr << HEX(8) << inc_int32[i].x << ", ";
-			cerr << "expected = " << inc_int32[i].fExpected << endl;
+			err_msg( "Error in case inc_int32 throw (2): ", inc_int32[i].x, inc_int32[i].fExpected );
 		}
 	}
 }
@@ -600,9 +576,7 @@ void PreIncTestInt64()
 
 		if( fSuccess != inc_int64[i].fExpected )
 		{
-			cerr << "Error in case inc_int64 throw (1): ";
-			cerr << HEX(8) << inc_int64[i].x << ", ";
-			cerr << "expected = " << inc_int64[i].fExpected << endl;
+			err_msg( "Error in case inc_int64 throw (1): ", inc_int64[i].x, inc_int64[i].fExpected );
 		}
 	}
 }
@@ -631,9 +605,7 @@ void PostIncTestInt64()
 
 		if( fSuccess != inc_int64[i].fExpected )
 		{
-			cerr << "Error in case inc_int64 throw (2): ";
-			cerr << HEX(8) << inc_int64[i].x << ", ";
-			cerr << "expected = " << inc_int64[i].fExpected << endl;
+			err_msg( "Error in case inc_int64 throw (2): ", inc_int64[i].x, inc_int64[i].fExpected );
 		}
 	}
 }
@@ -675,9 +647,7 @@ void PreDecTestUint8()
 
 		if( fSuccess != dec_uint8[i].fExpected )
 		{
-			cerr << "Error in case dec_uint8 throw (1): ";
-			cerr << HEX(2) << (0xFF & (int)dec_uint8[i].x) << ", ";
-			cerr << "expected = " << dec_uint8[i].fExpected << endl;
+			err_msg( "Error in case dec_uint8 throw (1): ", dec_uint8[i].x, dec_uint8[i].fExpected );
 		}
 	}
 }
@@ -706,9 +676,7 @@ void PostDecTestUint8()
 
 		if( fSuccess != dec_uint8[i].fExpected )
 		{
-			cerr << "Error in case dec_uint8 throw (2): ";
-			cerr << HEX(2) << (0xFF & (int)dec_uint8[i].x) << ", ";
-			cerr << "expected = " << dec_uint8[i].fExpected << endl;
+			err_msg( "Error in case dec_uint8 throw (2): ", dec_uint8[i].x, dec_uint8[i].fExpected );
 		}
 	}
 }
@@ -750,9 +718,7 @@ void PreDecTestUint16()
 
 		if( fSuccess != dec_uint16[i].fExpected )
 		{
-			cerr << "Error in case dec_uint16 throw (1): ";
-			cerr << HEX(4) << dec_uint16[i].x << ", ";
-			cerr << "expected = " << dec_uint16[i].fExpected << endl;
+			err_msg( "Error in case dec_uint16 throw (1): ", dec_uint16[i].x, dec_uint16[i].fExpected );
 		}
 	}
 }
@@ -781,9 +747,7 @@ void PostDecTestUint16()
 
 		if( fSuccess != dec_uint16[i].fExpected )
 		{
-			cerr << "Error in case dec_uint16 throw (2): ";
-			cerr << HEX(4) << dec_uint16[i].x << ", ";
-			cerr << "expected = " << dec_uint16[i].fExpected << endl;
+			err_msg( "Error in case dec_uint16 throw (2): ", dec_uint16[i].x, dec_uint16[i].fExpected );
 		}
 	}
 }
@@ -825,9 +789,7 @@ void PreDecTestUint32()
 
 		if( fSuccess != dec_uint32[i].fExpected )
 		{
-			cerr << "Error in case dec_uint32 throw (1): ";
-			cerr << HEX(8) << dec_uint32[i].x << ", ";
-			cerr << "expected = " << dec_uint32[i].fExpected << endl;
+			err_msg( "Error in case dec_uint32 throw (1): ", dec_uint32[i].x, dec_uint32[i].fExpected );
 		}
 	}
 }
@@ -856,9 +818,7 @@ void PostDecTestUint32()
 
 		if( fSuccess != dec_uint32[i].fExpected )
 		{
-			cerr << "Error in case dec_uint32 throw (2): ";
-			cerr << HEX(8) << dec_uint32[i].x << ", ";
-			cerr << "expected = " << dec_uint32[i].fExpected << endl;
+			err_msg( "Error in case dec_uint32 throw (2): ", dec_uint32[i].x, dec_uint32[i].fExpected );
 		}
 	}
 }
@@ -908,9 +868,9 @@ void PreDecTestUint64()
 
 		if( fSuccess != dec_uint64[i].fExpected )
 		{
-			cerr << "Error in case dec_uint64 throw (1): ";
-			cerr << HEX(16) << dec_uint64[i].x << ", ";
-			cerr << "expected = " << dec_uint64[i].fExpected << endl;
+			err_msg( "Error in case dec_uint64 throw (1): ",
+			dec_uint64[i].x,
+			dec_uint64[i].fExpected );
 		}
 	}
 }
@@ -939,9 +899,9 @@ void PostDecTestUint64()
 
 		if( fSuccess != dec_uint64[i].fExpected )
 		{
-			cerr << "Error in case dec_uint64 throw (2): ";
-			cerr << HEX(16) << dec_uint64[i].x << ", ";
-			cerr << "expected = " << dec_uint64[i].fExpected << endl;
+			err_msg( "Error in case dec_uint64 throw (2): ",
+			dec_uint64[i].x,
+			dec_uint64[i].fExpected );
 		}
 	}
 }
@@ -983,9 +943,7 @@ void PreDecTestInt8()
 
 		if( fSuccess != dec_int8[i].fExpected )
 		{
-			cerr << "Error in case dec_int8 throw (1): ";
-			cerr << HEX(2) << (0xFF & (int)dec_int8[i].x) << ", ";
-			cerr << "expected = " << dec_int8[i].fExpected << endl;
+			err_msg( "Error in case dec_int8 throw (1): ", dec_int8[i].x, dec_int8[i].fExpected );
 		}
 	}
 }
@@ -1014,9 +972,7 @@ void PostDecTestInt8()
 
 		if( fSuccess != dec_int8[i].fExpected )
 		{
-			cerr << "Error in case dec_int8 throw (2): ";
-			cerr << HEX(2) << (0xFF & (int)dec_int8[i].x) << ", ";
-			cerr << "expected = " << dec_int8[i].fExpected << endl;
+			err_msg( "Error in case dec_int8 throw (2): ", dec_int8[i].x, dec_int8[i].fExpected );
 		}
 	}
 }
@@ -1058,9 +1014,7 @@ void PreDecTestInt16()
 
 		if( fSuccess != dec_int16[i].fExpected )
 		{
-			cerr << "Error in case dec_int16 throw (1): ";
-			cerr << HEX(4) << dec_int16[i].x << ", ";
-			cerr << "expected = " << dec_int16[i].fExpected << endl;
+			err_msg( "Error in case dec_int16 throw (1): ", dec_int16[i].x, dec_int16[i].fExpected );
 		}
 	}
 }
@@ -1089,9 +1043,7 @@ void PostDecTestInt16()
 
 		if( fSuccess != dec_int16[i].fExpected )
 		{
-			cerr << "Error in case dec_int16 throw (2): ";
-			cerr << HEX(4) << dec_int16[i].x << ", ";
-			cerr << "expected = " << dec_int16[i].fExpected << endl;
+			err_msg( "Error in case dec_int16 throw (2): ", dec_int16[i].x, dec_int16[i].fExpected );
 		}
 	}
 }
@@ -1133,9 +1085,7 @@ void PreDecTestInt32()
 
 		if( fSuccess != dec_int32[i].fExpected )
 		{
-			cerr << "Error in case dec_int32 throw (1): ";
-			cerr << HEX(8) << dec_int32[i].x << ", ";
-			cerr << "expected = " << dec_int32[i].fExpected << endl;
+			err_msg( "Error in case dec_int32 throw (1): ", dec_int32[i].x, dec_int32[i].fExpected );
 		}
 	}
 }
@@ -1164,9 +1114,7 @@ void PostDecTestInt32()
 
 		if( fSuccess != dec_int32[i].fExpected )
 		{
-			cerr << "Error in case dec_int32 throw (2): ";
-			cerr << HEX(8) << dec_int32[i].x << ", ";
-			cerr << "expected = " << dec_int32[i].fExpected << endl;
+			err_msg( "Error in case dec_int32 throw (2): ", dec_int32[i].x, dec_int32[i].fExpected );
 		}
 	}
 }
@@ -1216,9 +1164,7 @@ void PreDecTestInt64()
 
 		if( fSuccess != dec_int64[i].fExpected )
 		{
-			cerr << "Error in case dec_int64 throw (1): ";
-			cerr << HEX(16) << dec_int64[i].x << ", ";
-			cerr << "expected = " << dec_int64[i].fExpected << endl;
+			err_msg( "Error in case dec_int64 throw (1): ", dec_int64[i].x, dec_int64[i].fExpected );
 		}
 	}
 }
@@ -1247,16 +1193,14 @@ void PostDecTestInt64()
 
 		if( fSuccess != dec_int64[i].fExpected )
 		{
-			cerr << "Error in case dec_int64 throw (2): ";
-			cerr << HEX(16) << dec_int64[i].x << ", ";
-			cerr << "expected = " << dec_int64[i].fExpected << endl;
+			err_msg( "Error in case dec_int64 throw (2): ", dec_int64[i].x, dec_int64[i].fExpected );
 		}
 	}
 }
 
 void IncDecVerify()
 {
-   cout << "Verifying Increment-decrement:" << endl;
+   std::cout << "Verifying Increment-decrement:" << std::endl;
 	PreIncTestUint8();
 	PostIncTestUint8();
 	PreIncTestUint16();

--- a/Test/ModVerify.cpp
+++ b/Test/ModVerify.cpp
@@ -13,14 +13,20 @@
 
 namespace mod_verify
 {
-
-enum Sign{ Unsigned, Signed };
+	template <typename T>
+	std::string type_name()
+	{
+		std::ostringstream ostm;
+		ostm << (std::numeric_limits<T>::is_signed ? "int" : "uint");
+		ostm << (sizeof(T) == 1 ? 8 : sizeof(T) * 8);
+		return ostm.str();
+	}
 
 // ModVerifyTest2 tests (x) % (0).
-template<typename T, Sign s>
+template<typename T>
 struct ModVerifyTest1
 {
-	ModVerifyTest1<T, s>()
+	ModVerifyTest1<T>()
 	{
 		const size_t width = sizeof(T);
 		const size_t shift = width * CHAR_BIT - 1;
@@ -45,25 +51,9 @@ struct ModVerifyTest1
 
 		if(divzero != expected)
 		{
-			cerr << "Error in case " << (s == Unsigned ? "u" : "");
-			cerr << "int" << dec << width*CHAR_BIT << " (1): ";
-
-#if !defined(__GNUC__)
-# pragma warning(disable: 4127)
-#endif
-			if(width > 1)
-			{
-				cerr << HEX(width*2) << (T)x << ", " << HEX(width*2) << (T)m << ", ";
-				cerr << "expected = " << (expected ? "divzero" : "no divzero") << endl;
-			}
-			else
-			{
-				cerr << HEX(2) << int(0xFF & (T)x) << ", " << HEX(2) << int(0xFF & (T)m) << ", ";
-				cerr << "expected = " << (expected ? "divzero" : "no divzero") << endl;
-			}
-#if !defined(__GNUC__)
-# pragma warning(default: 4127)
-#endif
+			std::cerr << "Error in case " << type_name<T>() << ": ";
+			std::cerr << to_hex((T)x) << ", " << to_hex((T)m) << ", ";
+			std::cerr << "expected = " << (expected ? "divzero" : "no divzero") << std::endl;
 		}
 
 		///////////////////////////////////////////////
@@ -81,34 +71,18 @@ struct ModVerifyTest1
 
 		if(divzero != expected)
 		{
-			cerr << "Error in case " << (s == Unsigned ? "u" : "");
-			cerr << "int" << dec << width*CHAR_BIT << " (2): ";
-
-#if !defined(__GNUC__)
-# pragma warning(disable: 4127)
-#endif
-			if(width > 1)
-			{
-				cerr << HEX(width*2) << (T)x << ", " << HEX(width*2) << (T)m << ", ";
-				cerr << "expected = " << (expected ? "divzero" : "no divzero") << endl;
-			}
-			else
-			{
-				cerr << HEX(2) << int(0xFF & (T)x) << ", " << HEX(2) << int(0xFF & (T)m) << ", ";
-				cerr << "expected = " << (expected ? "divzero" : "no divzero") << endl;
-			}
-#if !defined(__GNUC__)
-# pragma warning(default: 4127)
-#endif
+			std::cerr << "Error in case " << type_name<T>() << ": ";
+			std::cerr << to_hex((T)x) << ", " << to_hex((T)m) << ", ";
+			std::cerr << "expected = " << (expected ? "divzero" : "no divzero") << std::endl;
 		}
 	}
 };
 
 // ModVerifyTest2 tests (INT_MIN) % (-1).
-template<typename T, Sign s>
+template<typename T>
 struct ModVerifyTest2
 {
-	ModVerifyTest2<T, s>()
+	ModVerifyTest2<T>()
 	{
 		const size_t width = sizeof(T);
 		const size_t shift = width * CHAR_BIT - 1;
@@ -138,25 +112,9 @@ struct ModVerifyTest2
 
 		if(overflow != expected)
 		{
-			cerr << "Error in case " << (s == Unsigned ? "u" : "");
-			cerr << "int" << dec << width*CHAR_BIT << " (1): ";
-
-#if !defined(__GNUC__)
-# pragma warning(disable: 4127)
-#endif
-			if(width > 1)
-			{
-				cerr << HEX(width*2) << (T)x << ", " << HEX(width*2) << (T)m << ", ";
-				cerr << "expected = " << (expected ? "overflow" : "no overflow") << endl;
-			}
-			else
-			{
-				cerr << HEX(2) << int(0xFF & (T)x) << ", " << HEX(2) << int(0xFF & (T)m) << ", ";
-				cerr << "expected = " << (expected ? "overflow" : "no overflow") << endl;
-			}
-#if !defined(__GNUC__)
-# pragma warning(default: 4127)
-#endif
+			std::cerr << "Error in case " << type_name<T>() << ": ";
+			std::cerr << to_hex((T)x) << ", " << to_hex((T)m) << ", ";
+			std::cerr << "expected = " << (expected ? "overflow" : "no overflow") << std::endl;
 		}
 
 		///////////////////////////////////////////////
@@ -174,88 +132,45 @@ struct ModVerifyTest2
 
 		if(overflow != expected)
 		{
-			cerr << "Error in case " << (s == Unsigned ? "u" : "");
-			cerr << "int" << dec << width*CHAR_BIT << " (2): ";
-
-#if !defined(__GNUC__)
-# pragma warning(disable: 4127)
-#endif
-			if(width > 1)
-			{
-				cerr << HEX(width*2) << (T)x << ", " << HEX(width*2) << (T)m << ", ";
-				cerr << "expected = " << (expected ? "overflow" : "no overflow") << endl;
-			}
-			else
-			{
-				cerr << HEX(2) << int(0xFF & (T)x) << ", " << HEX(2) << int(0xFF & (T)m) << ", ";
-				cerr << "expected = " << (expected ? "overflow" : "no overflow") << endl;
-			}
-#if !defined(__GNUC__)
-# pragma warning(default: 4127)
-#endif
+			std::cerr << "Error in case " << type_name<T>() << ": ";
+			std::cerr << to_hex((T)x) << ", " << to_hex((T)m) << ", ";
+			std::cerr << "expected = " << (expected ? "overflow" : "no overflow") << std::endl;
 		}
 	}
 };
 
 void ModVerify()
 {
-	cout << "Verifying Reduction:" << endl;
+	std::cout << "Verifying Reduction:" << std::endl;
 
-	ModVerifyTest1<std::uint64_t, Unsigned> t11;
-	ModVerifyTest1<std::int64_t, Signed> t12;
+	ModVerifyTest1<std::uint64_t> t11;
+	ModVerifyTest1<std::int64_t> t12;
 
-	ModVerifyTest1<std::uint32_t, Unsigned> t13;
-	ModVerifyTest1<std::int32_t, Signed> t14;
+	ModVerifyTest1<std::uint32_t> t13;
+	ModVerifyTest1<std::int32_t> t14;
 
-	ModVerifyTest1<std::uint16_t, Unsigned> t15;
-	ModVerifyTest1<std::int16_t, Signed> t16;
+	ModVerifyTest1<std::uint16_t> t15;
+	ModVerifyTest1<std::int16_t> t16;
 
-	ModVerifyTest1<std::uint8_t, Unsigned> t17;
-	ModVerifyTest1<std::int8_t, Signed> t18;
+	ModVerifyTest1<std::uint8_t> t17;
+	ModVerifyTest1<std::int8_t> t18;
 
-#if defined(__GNUC__)
-	ModVerifyTest1<uint64_t, Unsigned> t31;
-	ModVerifyTest1<int64_t, Signed> t32;
 
-	ModVerifyTest1<uint32_t, Unsigned> t33;
-	ModVerifyTest1<int32_t, Signed> t34;
+	ModVerifyTest2<std::uint64_t> t21;
+	ModVerifyTest2<std::int64_t> t22;
 
-	ModVerifyTest1<uint16_t, Unsigned> t35;
-	ModVerifyTest1<int16_t, Signed> t36;
+	ModVerifyTest2<std::uint32_t> t23;
+	ModVerifyTest2<std::int32_t> t24;
 
-	ModVerifyTest1<uint8_t, Unsigned> t37;
-	ModVerifyTest1<int8_t, Signed> t38;
-#endif
+	ModVerifyTest2<std::uint16_t> t25;
+	ModVerifyTest2<std::int16_t> t26;
 
-	ModVerifyTest2<std::uint64_t, Unsigned> t21;
-	ModVerifyTest2<std::int64_t, Signed> t22;
-
-	ModVerifyTest2<std::uint32_t, Unsigned> t23;
-	ModVerifyTest2<std::int32_t, Signed> t24;
-
-	ModVerifyTest2<std::uint16_t, Unsigned> t25;
-	ModVerifyTest2<std::int16_t, Signed> t26;
-
-	ModVerifyTest2<std::uint8_t, Unsigned> t27;
-	ModVerifyTest2<std::int8_t, Signed> t28;
-
-#if defined(__GNUC__)
-	ModVerifyTest2<uint64_t, Unsigned> t41;
-	ModVerifyTest2<int64_t, Signed> t42;
-
-	ModVerifyTest2<uint32_t, Unsigned> t43;
-	ModVerifyTest2<int32_t, Signed> t44;
-
-	ModVerifyTest2<uint16_t, Unsigned> t45;
-	ModVerifyTest2<int16_t, Signed> t46;
-
-	ModVerifyTest2<uint8_t, Unsigned> t47;
-	ModVerifyTest2<int8_t, Signed> t48;
-#endif
+	ModVerifyTest2<std::uint8_t> t27;
+	ModVerifyTest2<std::int8_t> t28;
 
 	// Lets see.....
-	ModVerifyTest1<size_t, Unsigned> t50;
-	ModVerifyTest2<size_t, Unsigned> t51;
+	ModVerifyTest1<size_t> t50;
+	ModVerifyTest2<size_t> t51;
 }
 
 }

--- a/Test/MultVerify.cpp
+++ b/Test/MultVerify.cpp
@@ -162,12 +162,7 @@ void MultVerifyUint64Uint64()
 		if( SafeMultiply(uint64_uint64[i].x, uint64_uint64[i].y, ret) != uint64_uint64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case uint64_uint64: %I64X, %I64X, expected = %s\n",
-			// uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_uint64: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].y << ", ";
-			cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+			err_msg( "Error in case uint64_uint64: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
 		}
 
 		// Now test throwing version
@@ -184,12 +179,7 @@ void MultVerifyUint64Uint64()
 
 		if( fSuccess != uint64_uint64[i].fExpected )
 		{
-			// printf("Error in case uint64_uint64 throw: %I64X, %I64X, expected = %s\n",
-			// uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_uint64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].y << ", ";
-			cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+			err_msg( "Error in case uint64_uint64 throw: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
 		}
 	}
 }
@@ -274,12 +264,7 @@ void MultVerifyUint64Uint()
 		if( SafeMultiply(uint64_uint32[i].x, uint64_uint32[i].y, ret) != uint64_uint32[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_uint32: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].y << ", ";
-			cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+			err_msg( "Error in case uint64_uint32: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -295,12 +280,7 @@ void MultVerifyUint64Uint()
 
 		if( fSuccess != uint64_uint32[i].fExpected )
 		{
-			// printf("Error in case uint64_uint32 throw: %I64X, %I64X, expected = %s\n",
-			// uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_uint32 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].y << ", ";
-			cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+			err_msg( "Error in case uint64_uint32 throw: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
 		}
 	}
 }
@@ -385,12 +365,7 @@ void MultVerifyUintUint64()
 		if( SafeMultiply(uint32_uint64[i].x, uint32_uint64[i].y, ret) != uint32_uint64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// uint32_uint64[i].x, uint32_uint64[i].y, uint32_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint32_uint64: ";
-			cerr << hex << setw(16) << setfill('0') << uint32_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint32_uint64[i].y << ", ";
-			cerr << "expected = " << uint32_uint64[i].fExpected << endl;
+			err_msg( "Error in case uint32_uint64: ", uint32_uint64[i].x, uint32_uint64[i].y, uint32_uint64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -406,12 +381,7 @@ void MultVerifyUintUint64()
 
 		if( fSuccess != uint32_uint64[i].fExpected )
 		{
-			// printf("Error in case uint32_uint64 throw: %I64X, %I64X, expected = %s\n",
-			// uint32_uint64[i].x, uint32_uint64[i].y, uint32_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint32_uint64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint32_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint32_uint64[i].y << ", ";
-			cerr << "expected = " << uint32_uint64[i].fExpected << endl;
+			err_msg( "Error in case uint32_uint64 throw: ", uint32_uint64[i].x, uint32_uint64[i].y, uint32_uint64[i].fExpected );
 		}
 	}
 }
@@ -496,12 +466,7 @@ void MultVerifyUintInt64()
 		if( SafeMultiply(uint32_int64[i].x, uint32_int64[i].y, ret) != uint32_int64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// uint32_int64[i].x, uint32_int64[i].y, uint32_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint32_int64: ";
-			cerr << hex << setw(16) << setfill('0') << uint32_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint32_int64[i].y << ", ";
-			cerr << "expected = " << uint32_int64[i].fExpected << endl;
+			err_msg( "Error in case uint32_int64: ", uint32_int64[i].x, uint32_int64[i].y, uint32_int64[i].fExpected ); 
 		}
 
 		bool fSuccess = true;
@@ -517,12 +482,7 @@ void MultVerifyUintInt64()
 
 		if( fSuccess != uint32_int64[i].fExpected )
 		{
-			// printf("Error in case uint32_int64 throw: %I64X, %I64X, expected = %s\n",
-			// uint32_int64[i].x, uint32_int64[i].y, uint32_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint32_int64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint32_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint32_int64[i].y << ", ";
-			cerr << "expected = " << uint32_int64[i].fExpected << endl;
+			err_msg( "Error in case uint32_int64 throw: ", uint32_int64[i].x, uint32_int64[i].y, uint32_int64[i].fExpected );
 		}
 	}
 }
@@ -662,12 +622,7 @@ void MultVerifyUint64Int64()
 		if( SafeMultiply(uint64_int64[i].x, uint64_int64[i].y, ret) != uint64_int64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_int64: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int64[i].y << ", ";
-			cerr << "expected = " << uint64_int64[i].fExpected << endl;
+			err_msg( "Error in case uint64_int64: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -683,12 +638,7 @@ void MultVerifyUint64Int64()
 
 		if( fSuccess != uint64_int64[i].fExpected )
 		{
-			// printf("Error in case uint64_int64 throw: %I64X, %I64X, expected = %s\n",
-			// uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_int64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int64[i].y << ", ";
-			cerr << "expected = " << uint64_int64[i].fExpected << endl;
+			err_msg( "Error in case uint64_int64 throw: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
 		}
 	}
 }
@@ -773,12 +723,7 @@ void MultVerifyUint64Int()
 		if( SafeMultiply(uint64_int32[i].x, uint64_int32[i].y, ret) != uint64_int32[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_int32: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int32[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int32[i].y << ", ";
-			cerr << "expected = " << uint64_int32[i].fExpected << endl;
+			err_msg( "Error in case uint64_int32: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -794,12 +739,7 @@ void MultVerifyUint64Int()
 
 		if( fSuccess != uint64_int32[i].fExpected )
 		{
-			// printf("Error in case uint64_int32 throw: %I64X, %I64X, expected = %s\n",
-			// uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint64_int32 throw: ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int32[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << uint64_int32[i].y << ", ";
-			cerr << "expected = " << uint64_int32[i].fExpected << endl;
+			err_msg( "Error in case uint64_int32 throw: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
 		}
 	}
 }
@@ -941,12 +881,7 @@ void MultVerifyInt64Int64()
 		if( SafeMultiply(int64_int64[i].x, int64_int64[i].y, ret) != int64_int64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_int64: ";
-			cerr << hex << setw(16) << setfill('0') << int64_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_int64[i].y << ", ";
-			cerr << "expected = " << int64_int64[i].fExpected << endl;
+			err_msg( "Error in case int64_int64: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -962,12 +897,7 @@ void MultVerifyInt64Int64()
 
 		if( fSuccess != int64_int64[i].fExpected )
 		{
-			// printf("Error in case int64_int64 throw: %I64X, %I64X, expected = %s\n",
-			// int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_int64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << int64_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_int64[i].y << ", ";
-			cerr << "expected = " << int64_int64[i].fExpected << endl;
+			err_msg( "Error in case int64_int64 throw: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
 		}
 	}
 }
@@ -1109,12 +1039,7 @@ void MultVerifyInt64Uint64()
 		if( SafeMultiply(int64_uint64[i].x, int64_uint64[i].y, ret) != int64_uint64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_uint64: ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint64[i].y << ", ";
-			cerr << "expected = " << int64_uint64[i].fExpected << endl;
+			err_msg( "Error in case int64_uint64: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -1130,12 +1055,7 @@ void MultVerifyInt64Uint64()
 
 		if( fSuccess != int64_uint64[i].fExpected )
 		{
-			// printf("Error in case int64_uint64 throw: %I64X, %I64X, expected = %s\n",
-			// int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_uint64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint64[i].y << ", ";
-			cerr << "expected = " << int64_uint64[i].fExpected << endl;
+			err_msg( "Error in case int64_uint64 throw: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
 		}
 	}
 }
@@ -1220,12 +1140,7 @@ void MultVerifyInt64Int()
 		if( SafeMultiply(int64_int[i].x, int64_int[i].y, ret) != int64_int[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int64_int[i].x, int64_int[i].y, int64_int[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_int: ";
-			cerr << hex << setw(16) << setfill('0') << int64_int[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_int[i].y << ", ";
-			cerr << "expected = " << int64_int[i].fExpected << endl;
+			err_msg( "Error in case int64_int: ", int64_int[i].x, int64_int[i].y, int64_int[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -1241,12 +1156,7 @@ void MultVerifyInt64Int()
 
 		if( fSuccess != int64_int[i].fExpected )
 		{
-			// printf("Error in case int64_int throw: %I64X, %I64X, expected = %s\n",
-			// int64_int[i].x, int64_int[i].y, int64_int[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_int throw: ";
-			cerr << hex << setw(16) << setfill('0') << int64_int[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_int[i].y << ", ";
-			cerr << "expected = " << int64_int[i].fExpected << endl;
+			err_msg( "Error in case int64_int throw: ", int64_int[i].x, int64_int[i].y, int64_int[i].fExpected );
 		}
 	}
 }
@@ -1331,12 +1241,7 @@ void MultVerifyInt64Uint()
 		if( SafeMultiply(int64_uint[i].x, int64_uint[i].y, ret) != int64_uint[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int64_uint[i].x, int64_uint[i].y, int64_uint[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_uint: ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint[i].y << ", ";
-			cerr << "expected = " << int64_uint[i].fExpected << endl;
+			err_msg( "Error in case int64_uint: ", int64_uint[i].x, int64_uint[i].y, int64_uint[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -1352,12 +1257,7 @@ void MultVerifyInt64Uint()
 
 		if( fSuccess != int64_uint[i].fExpected )
 		{
-			// printf("Error in case int64_uint throw: %I64X, %I64X, expected = %s\n",
-			// int64_uint[i].x, int64_uint[i].y, int64_uint[i].fExpected ? "true" : "false");
-			cerr << "Error in case int64_uint throw: ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int64_uint[i].y << ", ";
-			cerr << "expected = " << int64_uint[i].fExpected << endl;
+			err_msg( "Error in case int64_uint throw: ", int64_uint[i].x, int64_uint[i].y, int64_uint[i].fExpected );
 		}
 	}
 }
@@ -1444,12 +1344,7 @@ void MultVerifyIntInt64()
 		if( SafeMultiply(int_int64[i].x, int_int64[i].y, ret) != int_int64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int_int64[i].x, int_int64[i].y, int_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int_int64: ";
-			cerr << hex << setw(16) << setfill('0') << int_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int_int64[i].y << ", ";
-			cerr << "expected = " << int_int64[i].fExpected << endl;
+			err_msg( "Error in case int_int64: ", int_int64[i].x, int_int64[i].y, int_int64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -1465,12 +1360,7 @@ void MultVerifyIntInt64()
 
 		if( fSuccess != int_int64[i].fExpected )
 		{
-			// printf("Error in case int_int64 throw: %I64X, %I64X, expected = %s\n",
-			// int_int64[i].x, int_int64[i].y, int_int64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int_int64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << int_int64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int_int64[i].y << ", ";
-			cerr << "expected = " << int_int64[i].fExpected << endl;
+			err_msg( "Error in case int_int64 throw: ", int_int64[i].x, int_int64[i].y, int_int64[i].fExpected );
 		}
 	}
 }
@@ -1557,12 +1447,7 @@ void MultVerifyIntUint64()
 		if( SafeMultiply(int_uint64[i].x, int_uint64[i].y, ret) != int_uint64[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case %I64X, %I64X, expected = %s\n",
-			// int_uint64[i].x, int_uint64[i].y, int_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int_uint64: ";
-			cerr << hex << setw(16) << setfill('0') << int_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int_uint64[i].y << ", ";
-			cerr << "expected = " << int_uint64[i].fExpected << endl;
+			err_msg( "Error in case int_uint64: ", int_uint64[i].x, int_uint64[i].y, int_uint64[i].fExpected );
 		}
 
 		bool fSuccess = true;
@@ -1578,12 +1463,7 @@ void MultVerifyIntUint64()
 
 		if( fSuccess != int_uint64[i].fExpected )
 		{
-			// printf("Error in case int_uint64 throw: %I64X, %I64X, expected = %s\n",
-			// int_uint64[i].x, int_uint64[i].y, int_uint64[i].fExpected ? "true" : "false");
-			cerr << "Error in case int_uint64 throw: ";
-			cerr << hex << setw(16) << setfill('0') << int_uint64[i].x << ", ";
-			cerr << hex << setw(16) << setfill('0') << int_uint64[i].y << ", ";
-			cerr << "expected = " << int_uint64[i].fExpected << endl;
+			err_msg( "Error in case int_uint64 throw: ", int_uint64[i].x, int_uint64[i].y, int_uint64[i].fExpected );
 		}
 	}
 }
@@ -1726,12 +1606,7 @@ void MultVerifyUint8Uint8()
 		if( SafeMultiply(uint8_uint8[i].x, uint8_uint8[i].y, ret) != uint8_uint8[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case uint8_uint8: %02X, %02X, expected = %s\n",
-			// uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint8_uint8: ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)uint8_uint8[i].x << ", ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)uint8_uint8[i].y << ", ";
-			cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+			err_msg( "Error in case uint8_uint8: ", (unsigned int)uint8_uint8[i].x, (unsigned int)uint8_uint8[i].y, uint8_uint8[i].fExpected );
 		}
 
 		// Now test throwing version
@@ -1748,12 +1623,7 @@ void MultVerifyUint8Uint8()
 
 		if( fSuccess != uint8_uint8[i].fExpected )
 		{
-			// printf("Error in case uint8_uint8 throw: %02X, %02X, expected = %s\n",
-			// uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected ? "true" : "false");
-			cerr << "Error in case uint8_uint8 throw: ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)uint8_uint8[i].x << ", ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)uint8_uint8[i].y << ", ";
-			cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+			err_msg( "Error in case uint8_uint8 throw: ", (unsigned int)uint8_uint8[i].x, (unsigned int)uint8_uint8[i].y, uint8_uint8[i].fExpected );
 		}
 	}
 }
@@ -1937,12 +1807,7 @@ void MultVerifyInt8Int8()
 		if( SafeMultiply(int8_int8[i].x, int8_int8[i].y, ret) != int8_int8[i].fExpected )
 		{
 			//assert(false);
-			// printf("Error in case int8_int8: %02X, %02X, expected = %s\n",
-			// int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected ? "true" : "false");
-			cerr << "Error in case int8_int8: ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)int8_int8[i].x << ", ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)int8_int8[i].y << ", ";
-			cerr << "expected = " << int8_int8[i].fExpected << endl;
+			err_msg( "Error in case int8_int8: ", (unsigned int)int8_int8[i].x, (unsigned int)int8_int8[i].y, int8_int8[i].fExpected );
 		}
 
 		// Now test throwing version
@@ -1959,19 +1824,14 @@ void MultVerifyInt8Int8()
 
 		if( fSuccess != int8_int8[i].fExpected )
 		{
-			// printf("Error in case int8_int8 throw: %02X, %02X, expected = %s\n",
-			// int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected ? "true" : "false");
-			cerr << "Error in case int8_int8 throw: ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)int8_int8[i].x << ", ";
-			cerr << hex << setw(2) << setfill('0') << (unsigned int)int8_int8[i].y << ", ";
-			cerr << "expected = " << int8_int8[i].fExpected << endl;
+			err_msg( "Error in case int8_int8 throw: ", (unsigned int)int8_int8[i].x, (unsigned int)int8_int8[i].y, int8_int8[i].fExpected );
 		}
 	}
 }
 
 void MultVerify()
 {
-	cout << "Verifying Multiplication:" << endl;
+	std::cout << "Verifying Multiplication:" << std::endl;
 
 	MultVerifyUint64Uint64();
 	MultVerifyUint64Uint();

--- a/Test/SubVerify.cpp
+++ b/Test/SubVerify.cpp
@@ -333,10 +333,7 @@ void SubVerifyUint64Uint64()
         std::uint64_t ret;
         if( SafeSubtract(uint64_uint64[i].x, uint64_uint64[i].y, ret) != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64: ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -353,10 +350,7 @@ void SubVerifyUint64Uint64()
 
         if( fSuccess != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64 throw (1): ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -374,10 +368,7 @@ void SubVerifyUint64Uint64()
 
         if( fSuccess != uint64_uint64[i].fExpected )
         {
-            cerr << "Error in case uint64_uint64 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint64[i].y << ", ";
-            cerr << "expected = " << uint64_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint64 throw (2): ", uint64_uint64[i].x, uint64_uint64[i].y, uint64_uint64[i].fExpected );
         }
     }
 }
@@ -556,10 +547,7 @@ void SubVerifyUint64Uint32()
         std::uint64_t ret;
         if( SafeSubtract(uint64_uint32[i].x, uint64_uint32[i].y, ret) != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32: ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -576,10 +564,7 @@ void SubVerifyUint64Uint32()
 
         if( fSuccess != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32 throw (1): ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -597,10 +582,7 @@ void SubVerifyUint64Uint32()
 
         if( fSuccess != uint64_uint32[i].fExpected )
         {
-            cerr << "Error in case uint64_uint32 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_uint32[i].y << ", ";
-            cerr << "expected = " << uint64_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint32 throw (2): ", uint64_uint32[i].x, uint64_uint32[i].y, uint64_uint32[i].fExpected );
         }
     }
 }
@@ -779,10 +761,7 @@ void SubVerifyUint64Uint16()
         std::uint64_t ret;
         if( SafeSubtract(uint64_uint16[i].x, uint64_uint16[i].y, ret) != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16: ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -799,10 +778,7 @@ void SubVerifyUint64Uint16()
 
         if( fSuccess != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16 throw (1): ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -820,10 +796,7 @@ void SubVerifyUint64Uint16()
 
         if( fSuccess != uint64_uint16[i].fExpected )
         {
-            cerr << "Error in case uint64_uint16 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_uint16[i].y << ", ";
-            cerr << "expected = " << uint64_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint16 throw (2): ", uint64_uint16[i].x, uint64_uint16[i].y, uint64_uint16[i].fExpected );
         }
     }
 }
@@ -1002,10 +975,7 @@ void SubVerifyUint64Uint8()
         std::uint64_t ret;
         if( SafeSubtract(uint64_uint8[i].x, uint64_uint8[i].y, ret) != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8: ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -1022,10 +992,7 @@ void SubVerifyUint64Uint8()
 
         if( fSuccess != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8 throw (1): ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1043,10 +1010,7 @@ void SubVerifyUint64Uint8()
 
         if( fSuccess != uint64_uint8[i].fExpected )
         {
-            cerr << "Error in case uint64_uint8 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_uint8[i].y) << ", ";
-            cerr << "expected = " << uint64_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint64_uint8 throw (2): ", uint64_uint8[i].x, uint64_uint8[i].y, uint64_uint8[i].fExpected );
         }
     }
 }
@@ -1233,10 +1197,7 @@ void SubVerifyUint8Uint64()
         std::uint8_t ret;
         if( SafeSubtract(uint8_uint64[i].x, uint8_uint64[i].y, ret) != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64: ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -1253,10 +1214,7 @@ void SubVerifyUint8Uint64()
 
         if( fSuccess != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64 throw (1): ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1274,10 +1232,7 @@ void SubVerifyUint8Uint64()
 
         if( fSuccess != uint8_uint64[i].fExpected )
         {
-            cerr << "Error in case uint8_uint64 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_uint64[i].y << ", ";
-            cerr << "expected = " << uint8_uint64[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint64 throw (2): ", uint8_uint64[i].x, uint8_uint64[i].y, uint8_uint64[i].fExpected );
         }
     }
 }
@@ -1384,10 +1339,7 @@ void SubVerifyUint8Uint32()
         std::uint8_t ret;
         if( SafeSubtract(uint8_uint32[i].x, uint8_uint32[i].y, ret) != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32: ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -1404,10 +1356,7 @@ void SubVerifyUint8Uint32()
 
         if( fSuccess != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32 throw (1): ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1425,10 +1374,7 @@ void SubVerifyUint8Uint32()
 
         if( fSuccess != uint8_uint32[i].fExpected )
         {
-            cerr << "Error in case uint8_uint32 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_uint32[i].y << ", ";
-            cerr << "expected = " << uint8_uint32[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint32 throw (2): ", uint8_uint32[i].x, uint8_uint32[i].y, uint8_uint32[i].fExpected );
         }
     }
 }
@@ -1535,10 +1481,7 @@ void SubVerifyUint8Uint16()
         std::uint8_t ret;
         if( SafeSubtract(uint8_uint16[i].x, uint8_uint16[i].y, ret) != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16: ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -1555,10 +1498,7 @@ void SubVerifyUint8Uint16()
 
         if( fSuccess != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16 throw (1): ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1576,10 +1516,7 @@ void SubVerifyUint8Uint16()
 
         if( fSuccess != uint8_uint16[i].fExpected )
         {
-            cerr << "Error in case uint8_uint16 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_uint16[i].y << ", ";
-            cerr << "expected = " << uint8_uint16[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint16 throw (2): ", uint8_uint16[i].x, uint8_uint16[i].y, uint8_uint16[i].fExpected );
         }
     }
 }
@@ -1686,10 +1623,7 @@ void SubVerifyUint8Uint8()
         std::uint8_t ret;
         if( SafeSubtract(uint8_uint8[i].x, uint8_uint8[i].y, ret) != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8: ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -1706,10 +1640,7 @@ void SubVerifyUint8Uint8()
 
         if( fSuccess != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8 throw (1): ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -1727,10 +1658,7 @@ void SubVerifyUint8Uint8()
 
         if( fSuccess != uint8_uint8[i].fExpected )
         {
-            cerr << "Error in case uint8_uint8 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_uint8[i].y) << ", ";
-            cerr << "expected = " << uint8_uint8[i].fExpected << endl;
+            err_msg( "Error in case uint8_uint8 throw (2): ", uint8_uint8[i].x, uint8_uint8[i].y, uint8_uint8[i].fExpected );
         }
     }
 }
@@ -2053,10 +1981,7 @@ void SubVerifyInt64Int64()
         std::int64_t ret;
         if( SafeSubtract(int64_int64[i].x, int64_int64[i].y, ret) != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64: ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64: ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -2073,10 +1998,7 @@ void SubVerifyInt64Int64()
 
         if( fSuccess != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64 throw (1): ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2094,10 +2016,7 @@ void SubVerifyInt64Int64()
 
         if( fSuccess != int64_int64[i].fExpected )
         {
-            cerr << "Error in case int64_int64 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_int64[i].y << ", ";
-            cerr << "expected = " << int64_int64[i].fExpected << endl;
+            err_msg( "Error in case int64_int64 throw (2): ", int64_int64[i].x, int64_int64[i].y, int64_int64[i].fExpected );
         }
     }
 }
@@ -2276,10 +2195,7 @@ void SubVerifyInt64Int32()
         std::int64_t ret;
         if( SafeSubtract(int64_int32[i].x, int64_int32[i].y, ret) != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32: ";
-            cerr << hex << setw(16) << setfill('0') << int64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32: ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -2296,10 +2212,7 @@ void SubVerifyInt64Int32()
 
         if( fSuccess != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32 throw (1): ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2317,10 +2230,7 @@ void SubVerifyInt64Int32()
 
         if( fSuccess != int64_int32[i].fExpected )
         {
-            cerr << "Error in case int64_int32 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_int32[i].y << ", ";
-            cerr << "expected = " << int64_int32[i].fExpected << endl;
+            err_msg( "Error in case int64_int32 throw (2): ", int64_int32[i].x, int64_int32[i].y, int64_int32[i].fExpected );
         }
     }
 }
@@ -2499,10 +2409,7 @@ void SubVerifyInt64Int16()
         std::int64_t ret;
         if( SafeSubtract(int64_int16[i].x, int64_int16[i].y, ret) != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16: ";
-            cerr << hex << setw(16) << setfill('0') << int64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16: ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -2519,10 +2426,7 @@ void SubVerifyInt64Int16()
 
         if( fSuccess != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16 throw (1): ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2540,10 +2444,7 @@ void SubVerifyInt64Int16()
 
         if( fSuccess != int64_int16[i].fExpected )
         {
-            cerr << "Error in case int64_int16 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_int16[i].y << ", ";
-            cerr << "expected = " << int64_int16[i].fExpected << endl;
+            err_msg( "Error in case int64_int16 throw (2): ", int64_int16[i].x, int64_int16[i].y, int64_int16[i].fExpected );
         }
     }
 }
@@ -2722,10 +2623,7 @@ void SubVerifyInt64Int8()
         std::int64_t ret;
         if( SafeSubtract(int64_int8[i].x, int64_int8[i].y, ret) != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8: ";
-            cerr << hex << setw(16) << setfill('0') << int64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8: ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -2742,10 +2640,7 @@ void SubVerifyInt64Int8()
 
         if( fSuccess != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8 throw (1): ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2763,10 +2658,7 @@ void SubVerifyInt64Int8()
 
         if( fSuccess != int64_int8[i].fExpected )
         {
-            cerr << "Error in case int64_int8 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_int8[i].y) << ", ";
-            cerr << "expected = " << int64_int8[i].fExpected << endl;
+            err_msg( "Error in case int64_int8 throw (2): ", int64_int8[i].x, int64_int8[i].y, int64_int8[i].fExpected );
         }
     }
 }
@@ -2953,10 +2845,7 @@ void SubVerifyInt8Int64()
         std::int8_t ret;
         if( SafeSubtract(int8_int64[i].x, int8_int64[i].y, ret) != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64: ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -2973,10 +2862,7 @@ void SubVerifyInt8Int64()
 
         if( fSuccess != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64 throw (1): ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -2994,10 +2880,7 @@ void SubVerifyInt8Int64()
 
         if( fSuccess != int8_int64[i].fExpected )
         {
-            cerr << "Error in case int8_int64 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_int64[i].y << ", ";
-            cerr << "expected = " << int8_int64[i].fExpected << endl;
+            err_msg( "Error in case int8_int64 throw (2): ", int8_int64[i].x, int8_int64[i].y, int8_int64[i].fExpected );
         }
     }
 }
@@ -3104,10 +2987,7 @@ void SubVerifyInt8Int32()
         std::int8_t ret;
         if( SafeSubtract(int8_int32[i].x, int8_int32[i].y, ret) != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32: ", int8_int32[i].x, int8_int32[i].y, int8_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -3124,10 +3004,8 @@ void SubVerifyInt8Int32()
 
         if( fSuccess != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32 throw (1): ", int8_int32[i].x, int8_int32[i].y,
+            int8_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3145,10 +3023,7 @@ void SubVerifyInt8Int32()
 
         if( fSuccess != int8_int32[i].fExpected )
         {
-            cerr << "Error in case int8_int32 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_int32[i].y << ", ";
-            cerr << "expected = " << int8_int32[i].fExpected << endl;
+            err_msg( "Error in case int8_int32 throw (2): ", int8_int32[i].x, int8_int32[i].y, int8_int32[i].fExpected );
         }
     }
 }
@@ -3255,10 +3130,7 @@ void SubVerifyInt8Int16()
         std::int8_t ret;
         if( SafeSubtract(int8_int16[i].x, int8_int16[i].y, ret) != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16: ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -3275,10 +3147,7 @@ void SubVerifyInt8Int16()
 
         if( fSuccess != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16 throw (1): ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3296,10 +3165,7 @@ void SubVerifyInt8Int16()
 
         if( fSuccess != int8_int16[i].fExpected )
         {
-            cerr << "Error in case int8_int16 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_int16[i].y << ", ";
-            cerr << "expected = " << int8_int16[i].fExpected << endl;
+            err_msg( "Error in case int8_int16 throw (2): ", int8_int16[i].x, int8_int16[i].y, int8_int16[i].fExpected );
         }
     }
 }
@@ -3406,10 +3272,7 @@ void SubVerifyInt8Int8()
         std::int8_t ret;
         if( SafeSubtract(int8_int8[i].x, int8_int8[i].y, ret) != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8: ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -3426,10 +3289,7 @@ void SubVerifyInt8Int8()
 
         if( fSuccess != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8 throw (1): ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3447,10 +3307,7 @@ void SubVerifyInt8Int8()
 
         if( fSuccess != int8_int8[i].fExpected )
         {
-            cerr << "Error in case int8_int8 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_int8[i].y) << ", ";
-            cerr << "expected = " << int8_int8[i].fExpected << endl;
+            err_msg( "Error in case int8_int8 throw (2): ", int8_int8[i].x, int8_int8[i].y, int8_int8[i].fExpected );
         }
     }
 }
@@ -3773,10 +3630,7 @@ void SubVerifyUint64Int64()
         std::uint64_t ret;
         if( SafeSubtract(uint64_int64[i].x, uint64_int64[i].y, ret) != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64: ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -3793,10 +3647,7 @@ void SubVerifyUint64Int64()
 
         if( fSuccess != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64 throw (1): ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -3814,10 +3665,7 @@ void SubVerifyUint64Int64()
 
         if( fSuccess != uint64_int64[i].fExpected )
         {
-            cerr << "Error in case uint64_int64 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int64[i].y << ", ";
-            cerr << "expected = " << uint64_int64[i].fExpected << endl;
+            err_msg( "Error in case uint64_int64 throw (2): ", uint64_int64[i].x, uint64_int64[i].y, uint64_int64[i].fExpected );
         }
     }
 }
@@ -3996,10 +3844,7 @@ void SubVerifyUint64Int32()
         std::uint64_t ret;
         if( SafeSubtract(uint64_int32[i].x, uint64_int32[i].y, ret) != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32: ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -4016,10 +3861,7 @@ void SubVerifyUint64Int32()
 
         if( fSuccess != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32 throw (1): ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4037,10 +3879,7 @@ void SubVerifyUint64Int32()
 
         if( fSuccess != uint64_int32[i].fExpected )
         {
-            cerr << "Error in case uint64_int32 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint64_int32[i].y << ", ";
-            cerr << "expected = " << uint64_int32[i].fExpected << endl;
+            err_msg( "Error in case uint64_int32 throw (2): ", uint64_int32[i].x, uint64_int32[i].y, uint64_int32[i].fExpected );
         }
     }
 }
@@ -4219,10 +4058,7 @@ void SubVerifyUint64Int16()
         std::uint64_t ret;
         if( SafeSubtract(uint64_int16[i].x, uint64_int16[i].y, ret) != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16: ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -4239,10 +4075,7 @@ void SubVerifyUint64Int16()
 
         if( fSuccess != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16 throw (1): ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4260,10 +4093,7 @@ void SubVerifyUint64Int16()
 
         if( fSuccess != uint64_int16[i].fExpected )
         {
-            cerr << "Error in case uint64_int16 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint64_int16[i].y << ", ";
-            cerr << "expected = " << uint64_int16[i].fExpected << endl;
+            err_msg( "Error in case uint64_int16 throw (2): ", uint64_int16[i].x, uint64_int16[i].y, uint64_int16[i].fExpected );
         }
     }
 }
@@ -4442,10 +4272,7 @@ void SubVerifyUint64Int8()
         std::uint64_t ret;
         if( SafeSubtract(uint64_int8[i].x, uint64_int8[i].y, ret) != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8: ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8: ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -4462,10 +4289,7 @@ void SubVerifyUint64Int8()
 
         if( fSuccess != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8 throw (1): ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4483,10 +4307,7 @@ void SubVerifyUint64Int8()
 
         if( fSuccess != uint64_int8[i].fExpected )
         {
-            cerr << "Error in case uint64_int8 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << uint64_int8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint64_int8[i].y) << ", ";
-            cerr << "expected = " << uint64_int8[i].fExpected << endl;
+            err_msg( "Error in case uint64_int8 throw (2): ", uint64_int8[i].x, uint64_int8[i].y, uint64_int8[i].fExpected );
         }
     }
 }
@@ -4673,10 +4494,7 @@ void SubVerifyUint8Int64()
         std::uint8_t ret;
         if( SafeSubtract(uint8_int64[i].x, uint8_int64[i].y, ret) != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64: ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
 
         // Now test throwing version
@@ -4693,10 +4511,7 @@ void SubVerifyUint8Int64()
 
         if( fSuccess != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64 throw (1): ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4714,10 +4529,7 @@ void SubVerifyUint8Int64()
 
         if( fSuccess != uint8_int64[i].fExpected )
         {
-            cerr << "Error in case uint8_int64 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << uint8_int64[i].y << ", ";
-            cerr << "expected = " << uint8_int64[i].fExpected << endl;
+            err_msg( "Error in case uint8_int64 throw (2): ", uint8_int64[i].x, uint8_int64[i].y, uint8_int64[i].fExpected );
         }
     }
 }
@@ -4824,10 +4636,7 @@ void SubVerifyUint8Int32()
         std::uint8_t ret;
         if( SafeSubtract(uint8_int32[i].x, uint8_int32[i].y, ret) != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32: ", uint8_int32[i].x, uint8_int32[i].y, uint8_int32[i].fExpected );
         }
 
         // Now test throwing version
@@ -4844,10 +4653,8 @@ void SubVerifyUint8Int32()
 
         if( fSuccess != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32 throw (1): ", uint8_int32[i].x, uint8_int32[i].y,
+            uint8_int32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -4865,10 +4672,7 @@ void SubVerifyUint8Int32()
 
         if( fSuccess != uint8_int32[i].fExpected )
         {
-            cerr << "Error in case uint8_int32 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << uint8_int32[i].y << ", ";
-            cerr << "expected = " << uint8_int32[i].fExpected << endl;
+            err_msg( "Error in case uint8_int32 throw (2): ", uint8_int32[i].x, uint8_int32[i].y, uint8_int32[i].fExpected );
         }
     }
 }
@@ -4975,10 +4779,7 @@ void SubVerifyUint8Int16()
         std::uint8_t ret;
         if( SafeSubtract(uint8_int16[i].x, uint8_int16[i].y, ret) != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16: ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
 
         // Now test throwing version
@@ -4995,10 +4796,7 @@ void SubVerifyUint8Int16()
 
         if( fSuccess != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16 throw (1): ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5016,10 +4814,7 @@ void SubVerifyUint8Int16()
 
         if( fSuccess != uint8_int16[i].fExpected )
         {
-            cerr << "Error in case uint8_int16 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << uint8_int16[i].y << ", ";
-            cerr << "expected = " << uint8_int16[i].fExpected << endl;
+            err_msg( "Error in case uint8_int16 throw (2): ", uint8_int16[i].x, uint8_int16[i].y, uint8_int16[i].fExpected );
         }
     }
 }
@@ -5126,10 +4921,7 @@ void SubVerifyUint8Int8()
         std::uint8_t ret;
         if( SafeSubtract(uint8_int8[i].x, uint8_int8[i].y, ret) != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8: ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
 
         // Now test throwing version
@@ -5146,10 +4938,7 @@ void SubVerifyUint8Int8()
 
         if( fSuccess != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8 throw (1): ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5167,10 +4956,7 @@ void SubVerifyUint8Int8()
 
         if( fSuccess != uint8_int8[i].fExpected )
         {
-            cerr << "Error in case uint8_int8 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)uint8_int8[i].y) << ", ";
-            cerr << "expected = " << uint8_int8[i].fExpected << endl;
+            err_msg( "Error in case uint8_int8 throw (2): ", uint8_int8[i].x, uint8_int8[i].y, uint8_int8[i].fExpected );
         }
     }
 }
@@ -5493,10 +5279,7 @@ void SubVerifyInt64Uint64()
         std::int64_t ret;
         if( SafeSubtract(int64_uint64[i].x, int64_uint64[i].y, ret) != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64: ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64: ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -5513,10 +5296,7 @@ void SubVerifyInt64Uint64()
 
         if( fSuccess != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64 throw (1): ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected ); 
         }
 
         // Also need to test the version that assigns back out
@@ -5534,10 +5314,7 @@ void SubVerifyInt64Uint64()
 
         if( fSuccess != int64_uint64[i].fExpected )
         {
-            cerr << "Error in case int64_uint64 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].x << ", ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint64[i].y << ", ";
-            cerr << "expected = " << int64_uint64[i].fExpected << endl;
+            err_msg( "Error in case int64_uint64 throw (2): ", int64_uint64[i].x, int64_uint64[i].y, int64_uint64[i].fExpected );
         }
     }
 }
@@ -5716,10 +5493,7 @@ void SubVerifyInt64Uint32()
         std::int64_t ret;
         if( SafeSubtract(int64_uint32[i].x, int64_uint32[i].y, ret) != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32: ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32: ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -5736,10 +5510,7 @@ void SubVerifyInt64Uint32()
 
         if( fSuccess != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32 throw (1): ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5757,10 +5528,7 @@ void SubVerifyInt64Uint32()
 
         if( fSuccess != int64_uint32[i].fExpected )
         {
-            cerr << "Error in case int64_uint32 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint32[i].x << ", ";
-            cerr << hex << setw(8) << setfill('0') << int64_uint32[i].y << ", ";
-            cerr << "expected = " << int64_uint32[i].fExpected << endl;
+            err_msg( "Error in case int64_uint32 throw (2): ", int64_uint32[i].x, int64_uint32[i].y, int64_uint32[i].fExpected );
         }
     }
 }
@@ -5939,10 +5707,7 @@ void SubVerifyInt64Uint16()
         std::int64_t ret;
         if( SafeSubtract(int64_uint16[i].x, int64_uint16[i].y, ret) != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16: ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16: ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -5959,10 +5724,7 @@ void SubVerifyInt64Uint16()
 
         if( fSuccess != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16 throw (1): ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -5980,10 +5742,7 @@ void SubVerifyInt64Uint16()
 
         if( fSuccess != int64_uint16[i].fExpected )
         {
-            cerr << "Error in case int64_uint16 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint16[i].x << ", ";
-            cerr << hex << setw(4) << setfill('0') << int64_uint16[i].y << ", ";
-            cerr << "expected = " << int64_uint16[i].fExpected << endl;
+            err_msg( "Error in case int64_uint16 throw (2): ", int64_uint16[i].x, int64_uint16[i].y, int64_uint16[i].fExpected );
         }
     }
 }
@@ -6162,10 +5921,7 @@ void SubVerifyInt64Uint8()
         std::int64_t ret;
         if( SafeSubtract(int64_uint8[i].x, int64_uint8[i].y, ret) != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8: ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8: ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -6182,10 +5938,7 @@ void SubVerifyInt64Uint8()
 
         if( fSuccess != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8 throw (1): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8 throw (1): ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6203,10 +5956,7 @@ void SubVerifyInt64Uint8()
 
         if( fSuccess != int64_uint8[i].fExpected )
         {
-            cerr << "Error in case int64_uint8 throw (2): ";
-            cerr << hex << setw(16) << setfill('0') << int64_uint8[i].x << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int64_uint8[i].y) << ", ";
-            cerr << "expected = " << int64_uint8[i].fExpected << endl;
+            err_msg( "Error in case int64_uint8 throw (2): ", int64_uint8[i].x, int64_uint8[i].y, int64_uint8[i].fExpected );
         }
     }
 }
@@ -6393,10 +6143,7 @@ void SubVerifyInt8Uint64()
         std::int8_t ret;
         if( SafeSubtract(int8_uint64[i].x, int8_uint64[i].y, ret) != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64: ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
 
         // Now test throwing version
@@ -6413,10 +6160,7 @@ void SubVerifyInt8Uint64()
 
         if( fSuccess != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64 throw (1): ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6434,10 +6178,7 @@ void SubVerifyInt8Uint64()
 
         if( fSuccess != int8_uint64[i].fExpected )
         {
-            cerr << "Error in case int8_uint64 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint64[i].x) << ", ";
-            cerr << hex << setw(16) << setfill('0') << int8_uint64[i].y << ", ";
-            cerr << "expected = " << int8_uint64[i].fExpected << endl;
+            err_msg( "Error in case int8_uint64 throw (2): ", int8_uint64[i].x, int8_uint64[i].y, int8_uint64[i].fExpected );
         }
     }
 }
@@ -6544,10 +6285,7 @@ void SubVerifyInt8Uint32()
         std::int8_t ret;
         if( SafeSubtract(int8_uint32[i].x, int8_uint32[i].y, ret) != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32: ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
 
         // Now test throwing version
@@ -6564,10 +6302,7 @@ void SubVerifyInt8Uint32()
 
         if( fSuccess != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32 throw (1): ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6585,10 +6320,7 @@ void SubVerifyInt8Uint32()
 
         if( fSuccess != int8_uint32[i].fExpected )
         {
-            cerr << "Error in case int8_uint32 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint32[i].x) << ", ";
-            cerr << hex << setw(8) << setfill('0') << int8_uint32[i].y << ", ";
-            cerr << "expected = " << int8_uint32[i].fExpected << endl;
+            err_msg( "Error in case int8_uint32 throw (2): ", int8_uint32[i].x, int8_uint32[i].y, int8_uint32[i].fExpected );
         }
     }
 }
@@ -6695,10 +6427,7 @@ void SubVerifyInt8Uint16()
         std::int8_t ret;
         if( SafeSubtract(int8_uint16[i].x, int8_uint16[i].y, ret) != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16: ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
 
         // Now test throwing version
@@ -6715,10 +6444,7 @@ void SubVerifyInt8Uint16()
 
         if( fSuccess != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16 throw (1): ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6736,10 +6462,7 @@ void SubVerifyInt8Uint16()
 
         if( fSuccess != int8_uint16[i].fExpected )
         {
-            cerr << "Error in case int8_uint16 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint16[i].x) << ", ";
-            cerr << hex << setw(4) << setfill('0') << int8_uint16[i].y << ", ";
-            cerr << "expected = " << int8_uint16[i].fExpected << endl;
+            err_msg( "Error in case int8_uint16 throw (2): ", int8_uint16[i].x, int8_uint16[i].y, int8_uint16[i].fExpected );
         }
     }
 }
@@ -6846,10 +6569,7 @@ void SubVerifyInt8Uint8()
         std::int8_t ret;
         if( SafeSubtract(int8_uint8[i].x, int8_uint8[i].y, ret) != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8: ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8: ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
 
         // Now test throwing version
@@ -6866,10 +6586,7 @@ void SubVerifyInt8Uint8()
 
         if( fSuccess != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8 throw (1): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8 throw (1): ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
 
         // Also need to test the version that assigns back out
@@ -6887,17 +6604,14 @@ void SubVerifyInt8Uint8()
 
         if( fSuccess != int8_uint8[i].fExpected )
         {
-            cerr << "Error in case int8_uint8 throw (2): ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].x) << ", ";
-            cerr << hex << setw(2) << setfill('0') << (0xFF & (int)int8_uint8[i].y) << ", ";
-            cerr << "expected = " << int8_uint8[i].fExpected << endl;
+            err_msg( "Error in case int8_uint8 throw (2): ", int8_uint8[i].x, int8_uint8[i].y, int8_uint8[i].fExpected );
         }
     }
 }
 
 void SubVerify()
 {
-    cout << "Verifying Subtraction:" << endl;
+    std::cout << "Verifying Subtraction:" << std::endl;
 
     // Unsigned int64, unsigned cases
     SubVerifyUint64Uint64();
@@ -6976,7 +6690,7 @@ namespace negation_verify
         }
 
         if (result == false)
-            cerr << "Error in NegationVerifyT throw (1): ";
+            std::cerr << "Error in NegationVerifyT throw (1): " << std::endl;
 
         try
         {
@@ -6988,19 +6702,19 @@ namespace negation_verify
         }
 
         if (result == false)
-            cerr << "Error in NegationVerifyT throw (2): ";
+            std::cerr << "Error in NegationVerifyT throw (2): " << std::endl;
 
         // Now try the non-throwing version
 
         result = SafeNegation(minInt, out);
 
         if (result != false)
-            cerr << "Error in NegationVerifyT nothrow (1): ";
+            std::cerr << "Error in NegationVerifyT nothrow (1): " << std::endl;
 
         result = SafeNegation(test, out);
 
         if (result == false)
-            cerr << "Error in NegationVerifyT nothrow (2): ";
+            std::cerr << "Error in NegationVerifyT nothrow (2): " << std::endl;
     }
 
     void NegationVerifyAll()
@@ -7013,7 +6727,7 @@ namespace negation_verify
 
     void NegationVerify()
     {
-        cout << "Verifying Negation:" << endl;
+        std::cout << "Verifying Negation:" << std::endl;
         NegationVerifyAll();
     }
 }

--- a/Test/TestMain.h
+++ b/Test/TestMain.h
@@ -11,16 +11,9 @@
 #endif
 
 #include <iostream>
+#include <ios>
 #include <iomanip>
-
-using std::cout;
-using std::cerr;
-using std::endl;
-
-using std::hex;
-using std::setw;
-using std::setfill;
-using std::dec;
+#include <sstream>
 
 #include "../SafeInt.hpp"
 
@@ -30,7 +23,6 @@ using std::dec;
 #pragma warning(disable: 4838 4477 4310 5045)
 #elif SAFEINT_COMPILER == CLANG_COMPILER 
 #pragma GCC diagnostic ignored "-Wc++11-narrowing"
-#pragma GCC diagnostic ignored "-Wformat"
 #elif SAFEINT_COMPILER == GCC_COMPILER
 #pragma GCC diagnostic ignored "-Wnarrowing"
 #endif
@@ -43,7 +35,41 @@ using std::dec;
 # endif
 #endif
 
-#define HEX(x) hex << setw(x) << setfill('0')
+template <typename T>
+std::string to_hex(T t)
+{
+	std::ostringstream ostm;
+	ostm << "0x" << std::setfill('0') << std::hex << std::setw(sizeof(t) <= 4 ? 8 : 16) << t;
+	return ostm.str();
+}
+
+template <>
+inline std::string to_hex< uint8_t >(uint8_t t)
+{
+	std::ostringstream ostm;
+	ostm << "0x" << std::setfill('0') << std::hex << std::setw(2) << static_cast<uint16_t>( t ) ;
+	return ostm.str();
+}
+
+template <>
+inline std::string to_hex< int8_t >(int8_t t)
+{
+	std::ostringstream ostm;
+	ostm << "0x" << std::setfill('0') << std::hex << std::setw(2) << static_cast<uint16_t>( t );
+	return ostm.str();
+}
+
+template <typename T, typename U>
+void err_msg(const std::string& msg, T t, U u, bool expected)
+{
+	std::cerr << msg << to_hex(t) << ", " << to_hex(u) << ", expected = " << expected << std::endl;
+}
+
+template <typename T>
+void err_msg(const std::string& msg, T t, bool expected)
+{
+	std::cerr << msg << to_hex(t) << ", expected = " << expected << std::endl;
+}
 
 namespace mult_verify { void MultVerify(); }
 namespace div_verify { void DivVerify(); }


### PR DESCRIPTION
This branch makes compiling with exceptions disabled supported. It encapsulates the class which throws inside a #ifdef, and if we can't throw exceptions, it makes the exception handler failfast on Windows, and abort() on everything else. If the user would like to do something else, as always, they are free to add their own exception handler.

Note - gcc is throwing some warnings with latest gcc, and I'll fix that before merging into main. Other than that, this branch can be used in production.