### PR TITLE
Do not overload wchar_t in environments where it fails to compile.

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -203,10 +203,6 @@ Please read the leading comments before using the class.
 // We're assuming two's complement negative numbers
 static_assert( -1 == static_cast<int>(0xffffffff), "Two's complement signed numbers are required" );
 
-#ifndef SAFEINT_SUPPORT_WCHAR
-#define SAFEINT_SUPPORT_WCHAR 1
-#endif
-
 /************* Compiler Options *****************************************************************************************************
 
 SafeInt supports several compile-time options that can change the behavior of the class.
@@ -243,14 +239,6 @@ SAFEINT_DISABLE_ADDRESS_OPERATOR   - Disables the overload of the & operator, wh
                                      modification, which is especially handy in legacy code bases. The drawback is that it breaks good C++
                                      practice, and breaks some libraries that auto-generate code. In the future, I expect to make disabling this the 
                                      default.
-
-SAFEINT_SUPPORT_WCHAR              - This should be 0 or 1 and defaults to 1.
-                                     In some environments, wchar_t is an alias to unsigned short,
-                                     and providing overloads for both fails to compile.
-                                     This is historical Visual C++ and Visual C++ with /Zc:wchar_t-.
-                                     /Zc:wchar_t- is non-conformant, but heavily used for compatibility.
-                                     Switching to the conformant mode changes mangled names.
-                                     This decision probably could be automatic.
 
 ************************************************************************************************************************************/
 
@@ -5839,7 +5827,8 @@ public:
         return val;
     }
 
-#if SAFEINT_SUPPORT_WCHAR
+// With Visual C++ /Zc:wchar_t- flag: typedef unsigned short wchar_t and the following function is an error.
+#if !defined(_MSC_VER) || defined(NATIVE_WCHAR_T_DEFINED)
 
     _CONSTEXPR14 operator wchar_t() const SAFEINT_CPP_THROW
     {

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -203,6 +203,10 @@ Please read the leading comments before using the class.
 // We're assuming two's complement negative numbers
 static_assert( -1 == static_cast<int>(0xffffffff), "Two's complement signed numbers are required" );
 
+#ifndef SAFEINT_SUPPORT_WCHAR
+#define SAFEINT_SUPPORT_WCHAR 1
+#endif
+
 /************* Compiler Options *****************************************************************************************************
 
 SafeInt supports several compile-time options that can change the behavior of the class.
@@ -239,6 +243,14 @@ SAFEINT_DISABLE_ADDRESS_OPERATOR   - Disables the overload of the & operator, wh
                                      modification, which is especially handy in legacy code bases. The drawback is that it breaks good C++
                                      practice, and breaks some libraries that auto-generate code. In the future, I expect to make disabling this the 
                                      default.
+
+SAFEINT_SUPPORT_WCHAR              - This should be 0 or 1 and defaults to 1.
+                                     In some environments, wchar_t is an alias to unsigned short,
+                                     and providing overloads for both fails to compile.
+                                     This is historical Visual C++ and Visual C++ with /Zc:wchar_t-.
+                                     /Zc:wchar_t- is non-conformant, but heavily used for compatibility.
+                                     Switching to the conformant mode changes mangled names.
+                                     This decision probably could be automatic.
 
 ************************************************************************************************************************************/
 
@@ -5827,12 +5839,16 @@ public:
         return val;
     }
 
+#if SAFEINT_SUPPORT_WCHAR
+
     _CONSTEXPR14 operator wchar_t() const SAFEINT_CPP_THROW
     {
         wchar_t val = 0;
         SafeCastHelper< wchar_t, T, GetCastMethod< wchar_t, T >::method >::template CastThrow< E >( m_int, val );
         return val;
     }
+
+#endif
 
 #ifdef SIZE_T_CAST_NEEDED
     // We also need an explicit cast to size_t, or the compiler will complain

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5828,7 +5828,7 @@ public:
     }
 
 // With Visual C++ /Zc:wchar_t- flag: typedef unsigned short wchar_t and the following function is an error.
-#if !defined(_MSC_VER) || defined(NATIVE_WCHAR_T_DEFINED)
+#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
 
     _CONSTEXPR14 operator wchar_t() const SAFEINT_CPP_THROW
     {


### PR DESCRIPTION
This provides compatibility with environments for which wchar_t is an alias
for unsigned short, which is the historical case on Visual C++, and still with /Zc:wchar_t-.

That is, historically:
 typedef unsigned short wchar_t;

 void f(unsigned short) { }
 void f(wchar_t) { } // error

Making wchar_t a unique builtin type is conformant, allows the above, and changes
the name mangling in preexisting code.