### PR TITLE
Fix double to long double clang 10.0 diagnostic.

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5862,7 +5862,7 @@ public:
     }
     _CONSTEXPR14 operator long double() const SAFEINT_CPP_THROW
     {
-        long double val = 0.0;
+        long double val = 0.0L;
         SafeCastHelper< long double, T, GetCastMethod< long double, T >::method >::template CastThrow< E >( m_int, val );
         return val;
     }


### PR DESCRIPTION
.../safeint.hpp.original:5868:27: error: implicit conversion increases floating-point precision: 'double' to 'long double' [-Werror,-Wdouble-promotion]
        long double val = 0.0;

We could do this:

```
#ifdef __clang__
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wdouble-promotion"
#endif

...

#ifdef __clang__
#pragma clang diagnostic pop
#endif
```

Or add L suffix, which is safe.