### PR TITLE
Fix clang diagnostic about deprecated generated copy constructor.

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5669,6 +5669,12 @@ public:
         static_assert( safeint_internal::numeric_type< T >::isInt, "Integer type required" );
     }
 
+#if CPLUSPLUS_STD >= CPLUSPLUS_11
+    _CONSTEXPR11 SafeInt(const SafeInt& other) SAFEINT_NOTHROW = default;
+#else
+    _CONSTEXPR11 SafeInt(const SafeInt& other) SAFEINT_NOTHROW : m_int(other.m_int) { }
+#endif
+
     // Having a constructor for every type of int
     // avoids having the compiler evade our checks when doing implicit casts -
     // e.g., SafeInt<char> s = 0x7fffffff;
@@ -5735,11 +5741,15 @@ public:
         return *this;
     }
 
+#if CPLUSPLUS_STD >= CPLUSPLUS_11
+    _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW = default;
+#else
     _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW
     {
         m_int = rhs.m_int;
         return *this;
     }
+#endif
 
     // Casting operators
 

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5669,12 +5669,6 @@ public:
         static_assert( safeint_internal::numeric_type< T >::isInt, "Integer type required" );
     }
 
-#if CPLUSPLUS_STD >= CPLUSPLUS_11
-    _CONSTEXPR11 SafeInt(const SafeInt& other) SAFEINT_NOTHROW = default;
-#else
-    _CONSTEXPR11 SafeInt(const SafeInt& other) SAFEINT_NOTHROW : m_int(other.m_int) { }
-#endif
-
     // Having a constructor for every type of int
     // avoids having the compiler evade our checks when doing implicit casts -
     // e.g., SafeInt<char> s = 0x7fffffff;
@@ -5740,16 +5734,6 @@ public:
         SafeCastHelper< T, U, GetCastMethod< T, U >::method >::template CastThrow< E >( rhs.Ref(), m_int );
         return *this;
     }
-
-#if CPLUSPLUS_STD >= CPLUSPLUS_11
-    _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW = default;
-#else
-    _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW
-    {
-        m_int = rhs.m_int;
-        return *this;
-    }
-#endif
 
     // Casting operators
 


### PR DESCRIPTION
Fix implicit copy constructor clang 10.0 diagnostic (-Weverything, that we use).

.../safeint.hpp.original:5741:35: error: 
definition of implicit copy constructor for 'SafeInt<long, SafeIntInternal::SafeIntExceptionHandler<SafeIntException> >' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
_CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW
^
.../safeint.hpp.original:6536:12: note: in implicit copy constructor for 'SafeInt<long, SafeIntInternal::SafeIntExceptionHandler<SafeIntException> >' first required here
return SafeInt<ptrdiff_t, SafeIntDefaultExceptionHandler>( p1 - p2 );
^
There are many ways to fix this.

1. Suppress it: 

```    
#ifdef __clang__
#pragma clang diagnostic ignored "-Wdouble-promotion"
#pragma clang diagnostic ignored "-Wdeprecated-copy"
#endif

...

#ifdef __clang__
#pragma clang diagnostic pop
#endif
```

2.  We can remove the operator= and let the compiler supply the default for both.
    This seems like a good idea.
    That is done here.
    It is smallest source, and works and has the same meaning in C++98 and newer.

3.  We can provide copy constructor, that the compiler was providing anyway:
```
_CONSTEXPR11 SafeInt(const SafeInt& 
other) SAFEINT_NOTHROW : 
m_int(other.m_int) { }
```

   Experimentation suggests the compiler-supplied copy constructor is not explicit.
   i.e. this program:

```
class A
{
public:

A(int) { }

explicit
A(const A&) {}

void operator=(const A&) { } // warning here, depending on if previous present

};

A f1();
A f1()
{
return A(1);
}
```

add/remove the copy constructor, and add/remove explicit.
It does compile, with warning, w/o the copy constructor.
It does not compile if the copy constructor is explicit.

This is ok, but then we have two manually provided functions, for which
the compiler can produce the same thing. One small difference, is these can be more easily stepped though.

4. We can declare both, but say they are "=default", a C++11 feature.
   This is really the same as option 2, let the compiler do it, albeit slightly explicit.
   This would require conditionality on C++11 vs. 98.