### PR TITLE
Disable x64-specific optimizations for ARM64EC

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -182,7 +182,7 @@ Please read the leading comments before using the class.
 // Note - intrinsics and constexpr are mutually exclusive
 // If it is important to get constexpr for multiplication, then define SAFEINT_USE_INTRINSICS 0
 // However, intrinsics will result in much smaller code, and should have better perf
-#if SAFEINT_COMPILER == VISUAL_STUDIO_COMPILER && defined _M_AMD64 && !defined SAFEINT_USE_INTRINSICS
+#if SAFEINT_COMPILER == VISUAL_STUDIO_COMPILER && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && !defined SAFEINT_USE_INTRINSICS
     #include <intrin.h>
     #define SAFEINT_USE_INTRINSICS 1
     #define _CONSTEXPR14_MULTIPLY 


### PR DESCRIPTION
ARM64EC is a new ARM64 ABI for supporting fast x64 application emulation on ARM64. When the compiler is compiling for ARM64EC, both the macro _M_AMD64 and _M_ARM64EC are defined, and those x64-specific code guarded only by testing defined(_M_AMD64) will be compiled to ARM64EC, for maximizing compatibility with x64 code. However, ARM64EC may not support certain x64 intrinsics, so that happens (like what this PR touches), we should prevent such x64 code paths to be compiled as ARM64EC, and instead use the code paths for ARM64.