### PR TITLE
Use long double constant suffix

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5971,7 +5971,7 @@ public:
     }
     _CONSTEXPR14 operator long double() const SAFEINT_CPP_THROW
     {
-        long double val = 0.0;
+        long double val = 0.0L;
         SafeCastHelper< long double, T, GetCastMethod< long double, T >::method >::template CastThrow< E >( m_int, val );
         return val;
     }


### PR DESCRIPTION
Without the L suffix, how constants (without a suffix) are converted to the long double type depend on FLT_EVAL_METHOD.
This causes a compilation error when using -Wdouble-promotion and -Werror.