### PR TITLE
Add support for compiling with -Wextra, fix warnings that ensue

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5800,6 +5800,12 @@ public:
         m_int = (T)SafeInt< T, E >( (U)u );
     }
 
+    _CONSTEXPR14 SafeInt(const SafeInt< T, E >& t) SAFEINT_CPP_THROW : m_int(0)
+    {
+        static_assert(safeint_internal::numeric_type< T >::isInt, "Integer type required");
+        m_int = t.m_int;
+    }
+
     template < typename U >
     _CONSTEXPR14 SafeInt( const U& i ) SAFEINT_CPP_THROW : m_int(0)
     {
@@ -6639,7 +6645,7 @@ private:
 template <typename P>
 _CONSTEXPR11 SafeInt<ptrdiff_t, SafeIntDefaultExceptionHandler> SafePtrDiff(const P* p1, const P* p2) SAFEINT_CPP_THROW
 {
-    return SafeInt<ptrdiff_t, SafeIntDefaultExceptionHandler>( p1 - p2 );
+    return ( p1 - p2 );
 }
 
 // Comparison operators

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -111,7 +111,7 @@ else()
         ../../SafeInt.hpp
     )
 
-    target_compile_options(CompileTest_clang PUBLIC -Wall)
+    target_compile_options(CompileTest_clang PUBLIC -Wall -Wextra)
 
     add_executable(CompileTest_clang14
         ../CompileTest.cpp


### PR DESCRIPTION
If using -WExtra, it turns out that an explicit copy constructor for type T, not just type U is needed. Also, the construct of return SafeInt<ptrdiff_t>(p1-p2); is not happy, where return (p1 - p2); works, as we call a well-defined constructor, not a copy constructor.