### PR TITLE
Cpp 98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /Test/c_safe_math/Release
 /Test/c_safe_math/x64/Release
 build/
+/Test/MsvcTest/.vs
+/Test/MsvcTest/CMakeSettings.json
+/.vs
+Test/c_safe_math/c_safe_math.vcxproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,5 +24,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_subdirectory(Test/ClangTest)
 add_subdirectory(Test/GccTest)
+add_subdirectory(Test/MsvcTest)
 
 enable_testing()

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -414,9 +414,9 @@ enum SafeIntError
 // Now we need to define an exception handler
 // Internally defined exception handlers might assert
 #if defined SAFEINT_ASSERT_ON_EXCEPTION
-inline void SafeIntExceptionAssert() SAFEINT_NOTHROW { SAFEINT_ASSERT(false); }
+static inline void SafeIntExceptionAssert() SAFEINT_NOTHROW { SAFEINT_ASSERT(false); }
 #else
-inline void SafeIntExceptionAssert() SAFEINT_NOTHROW {}
+static inline void SafeIntExceptionAssert() SAFEINT_NOTHROW {}
 #endif
 
 #define SAFEINT_EXCEPTION_WIN32 0
@@ -5085,7 +5085,7 @@ public:
 
         // We need the absolute value of std::numeric_limits<T>::min()
         // This will give it to us without extraneous compiler warnings
-        const std::uint64_t AbsMinIntT = (std::uint64_t)std::numeric_limits<T>::max() + 1;
+        _CONSTEXPR11 std::uint64_t AbsMinIntT = (std::uint64_t)std::numeric_limits<T>::max() + 1;
 
         if( lhs < 0 )
         {

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -435,8 +435,6 @@ inline void SafeIntExceptionAssert() SAFEINT_NOTHROW {}
     #endif
 #endif
 
-template < typename E > class SafeIntExceptionHandler;
-
 #if SAFEINT_EXCEPTION_METHOD == SAFEINT_EXCEPTION_CPP
 
 class SAFEINT_VISIBLE SafeIntException
@@ -453,6 +451,8 @@ public:
 // whether it was put there correctly in the first place
 namespace safeint_exception_handlers
 {
+    template < typename E > class SafeIntExceptionHandler;
+
     // Some users may have applications that do not use C++ exceptions
     // and cannot compile the following class. If that is the case,
     // either SafeInt_InvalidParameter must be defined as the default,

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -111,7 +111,7 @@ else()
         ../../SafeInt.hpp
     )
 
-    target_compile_options(CompileTest_clang PUBLIC -Wall)
+    target_compile_options(CompileTest_clang PUBLIC -Wall -Wextra)
 
     add_executable(CompileTest_clang14
         ../CompileTest.cpp

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -160,6 +160,7 @@ else()
 
     add_executable(safe_math_compile_clang
         ../c_safe_math/safe_math_compile.c
+        ../c_safe_math/compile_test.c
         ../../safe_math.h
         ../../safe_math_impl.h
     )

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -120,7 +120,16 @@ else()
         ../../SafeInt.hpp
     )
 
-    target_compile_options(CompileTest_clang14 PUBLIC -Wall -std=c++14)
+    target_compile_options(CompileTest_clang14 PUBLIC -Wall  -Wextra -std=c++14)
+
+    add_executable(CompileTest_clang17
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_clang17 PUBLIC -Wall  -Wextra -std=c++17)
 
     add_executable(CompileTest_clang14_NoEH
         ../CompileTest.cpp
@@ -129,7 +138,16 @@ else()
         ../../SafeInt.hpp
     )
 
-    target_compile_options(CompileTest_clang14_NoEH PUBLIC -Wall -std=c++14 -fno-exceptions)
+    target_compile_options(CompileTest_clang14_NoEH PUBLIC -Wall  -Wextra -std=c++14 -fno-exceptions)
+
+    add_executable(CompileTest_clang17_NoEH
+        ../CompileTest.cpp
+        ../ConstExpr.cpp 
+        ../CleanCompile.cpp
+        ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_clang17_NoEH PUBLIC -Wall  -Wextra -std=c++17 -fno-exceptions)
 
     add_executable(CompileTest_clang98
         ../CompileTest.cpp

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -131,6 +131,15 @@ else()
 
     target_compile_options(CompileTest_clang14_NoEH PUBLIC -Wall -std=c++14 -fno-exceptions)
 
+    add_executable(CompileTest_clang98
+        ../CompileTest.cpp
+        ../ConstExpr.cpp 
+        ../CleanCompile.cpp
+        ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_clang98 PUBLIC -D SAFEINT_USE_CPLUSCPLUS_98 -Wall -std=c++98 -fno-exceptions)
+
     add_executable(safe_math_test_clang
         ../c_safe_math/safe_math_test.c
         ../c_safe_math/safe_math_test.h

--- a/Test/ClangTest/makefile
+++ b/Test/ClangTest/makefile
@@ -19,6 +19,9 @@ SafeIntTest_NoIntrinsic: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../
 SafeIntTest_NoInt128: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
 	clang++ --std=c++11 -O3 -D SAFEINT_HAS_INT128=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest_NoInt128 2> SafeIntTest_NoInt128.err
 
+CompileTest98: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
+	clang++ -Wall -D SAFEINT_USE_CPLUSCPLUS_98 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest 2> CompileTest.err
+
 CompileTest: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	clang++ -Wall --std=c++11 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest 2> CompileTest.err
 

--- a/Test/CompileTest.cpp
+++ b/Test/CompileTest.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #if !defined __GNUC__
-#pragma warning( disable: 4571 4820 4514 4987 4710 4309 4986 4548 4189)
+#pragma warning( disable: 4571 4820 4514 4987 4710 4309 4986 4548 4189 4866)
 // relative include path contains '..'
 // (function) selected for automatic inline expansion
 #pragma warning( disable: 4464 4711 )
@@ -11,6 +11,7 @@
 #endif
 
 #include "../SafeInt.hpp"
+
 
 void ConstExpr();
 

--- a/Test/CompileTest.cpp
+++ b/Test/CompileTest.cpp
@@ -252,7 +252,7 @@ void CompileType()
 	T x = 1;
 	T result;
 
-	SafeNegation(x, result);
+	(void)SafeNegation(x, result);
 
 }
 

--- a/Test/GccTest/CMakeLists.txt
+++ b/Test/GccTest/CMakeLists.txt
@@ -150,6 +150,7 @@ else()
 
     add_executable(safe_math_compile_gcc
     ../c_safe_math/safe_math_compile.c
+    ../c_safe_math/compile_test.c
     ../../safe_math.h
     ../../safe_math_impl.h
 )

--- a/Test/GccTest/CMakeLists.txt
+++ b/Test/GccTest/CMakeLists.txt
@@ -123,6 +123,15 @@ else()
 
     target_compile_options(CompileTest_gcc14_NoEH PUBLIC -Wall -std=c++14 -fno-exceptions)
 
+    add_executable(CompileTest_gcc98
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_gcc98 PUBLIC -D SAFEINT_USE_CPLUSCPLUS_98 -Wall -std=c++98 -fno-exceptions)
+
     add_executable(safe_math_test_gcc
     ../c_safe_math/safe_math_test.c
     ../c_safe_math/safe_math_test.h

--- a/Test/MsvcTest/CMakeLists.txt
+++ b/Test/MsvcTest/CMakeLists.txt
@@ -1,0 +1,152 @@
+cmake_minimum_required(VERSION 3.10)
+project(SafeInt VERSION 3.0.26)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Runtime tests are:
+# - default
+# - without built-in 128-bit support
+# - without intrinsics
+
+# Compile time tests are:
+# - default C++11
+# - C++14
+# - TODO - consider adding in 17, 20 just to see if anything breaks
+# - compile without exceptions
+
+# Supported compilers:
+# - Microsoft
+# - clang
+# - gcc
+# - Intel (not regularly tested)
+# other compilers on a best effort
+
+# test for g++
+find_program(MSVC_CL "cl.exe")
+
+if(NOT MSVC_CL)
+    message(STATUS "Skipping MSVC testing")
+else()
+    message(STATUS "MSVC available, configuring MSVC tests")
+    set(CMAKE_CXX_COMPILER ${MSVC_CL})
+
+    # the standard level is already at C++11, which is what we need for runtime tests
+    add_compile_options(/Wall)
+
+    # This will test whatever the mainline code can do, typically using int128
+    add_executable(SafeIntTest_msvc 
+        ../AddVerify.cpp 
+        ../AddTestCase.cpp
+        ../CastVerify.cpp 
+        ../DivVerify.cpp 
+        ../DivTestCase.cpp
+        ../IncDecVerify.cpp 
+        ../ModVerify.cpp 
+        ../MultVerify.cpp 
+        ../MultTestCase.cpp
+        ../SubVerify.cpp 
+        ../SubTestCase.cpp
+        ../TestMain.cpp
+        ../TestMain.h
+        ../../SafeInt.hpp
+    )
+    
+        # Forces use of the older, less efficient code that can't use either int128 or intrinsics
+        add_executable(SafeIntTest_msvc_NoIntrinsic
+        ../AddVerify.cpp 
+        ../AddTestCase.cpp
+        ../CastVerify.cpp 
+        ../DivVerify.cpp 
+        ../DivTestCase.cpp
+        ../IncDecVerify.cpp 
+        ../ModVerify.cpp 
+        ../MultVerify.cpp 
+        ../MultTestCase.cpp
+        ../SubVerify.cpp 
+        ../SubTestCase.cpp
+        ../TestMain.cpp
+        ../TestMain.h
+        ../../SafeInt.hpp
+    )
+
+    target_compile_definitions(SafeIntTest_msvc_NoIntrinsic PUBLIC "SAFEINT_USE_INTRINSICS=0" "SAFEINT_HAS_INT128=0")
+
+    # compilation tests, these are good if they just build
+    add_executable(CompileTest_msvc
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_msvc PUBLIC /wd4711 /wd4710)
+
+    add_executable(CompileTest_msvc14
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_msvc14 PUBLIC /std:c++14 /wd4711)
+
+    add_executable(CompileTest_msvc17
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_msvc17 PUBLIC /std:c++17)
+
+    # compilation tests, these are good if they just build
+    add_executable(CompileTest_msvc_noexcept
+    ../CompileTest.cpp
+    ../ConstExpr.cpp 
+    ../CleanCompile.cpp
+    ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_msvc_noexcept PUBLIC /wd4711 /wd4710 /EHsc)
+
+    add_executable(safe_math_test_msvc
+    ../c_safe_math/safe_math_test.c
+    ../c_safe_math/safe_math_test.h
+    ../c_safe_math/safe_math_test_add.cpp
+    ../c_safe_math/safe_math_test_div.cpp
+    ../c_safe_math/safe_math_test_mult.cpp
+    ../c_safe_math/safe_math_test_sub.cpp
+    ../c_safe_math/compile_test.cpp
+    ../AddTestCase.cpp
+    ../DivTestCase.cpp
+    ../MultTestCase.cpp
+    ../SubTestCase.cpp
+    )
+
+    target_compile_definitions(safe_math_test_msvc PUBLIC)
+    target_compile_options(safe_math_test_msvc PUBLIC /wd4464)
+
+    add_executable(safe_math_compile_msvc
+    ../c_safe_math/safe_math_compile.c
+    ../c_safe_math/compile_test.c
+    ../../safe_math.h
+    ../../safe_math_impl.h
+    )
+
+    target_compile_options(safe_math_compile_msvc PUBLIC -Wall /wd4464)
+
+endif()
+
+enable_testing()
+
+if(MSVC_CL)
+    add_test(NAME SafeIntTest_msvc COMMAND SafeIntTest_msvc)
+    add_test(NAME SafeIntTest_msvc_NoIntrinsic COMMAND SafeIntTest_msvc_NoIntrinsic)
+    add_test(NAME safe_math_test_msvc COMMAND safe_math_test_msvc)
+
+    set_tests_properties(SafeIntTest_msvc 
+                        SafeIntTest_msvc_NoIntrinsic 
+                        safe_math_test_msvc
+                        PROPERTIES FAIL_REGULAR_EXPRESSION "Error")
+endif()

--- a/Test/MsvcTest/CMakeLists.txt
+++ b/Test/MsvcTest/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
     set(CMAKE_CXX_COMPILER ${MSVC_CL})
 
     # the standard level is already at C++11, which is what we need for runtime tests
-    add_compile_options(/Wall)
+    add_compile_options(/Wall /wd4710 /wd4711)
 
     # This will test whatever the mainline code can do, typically using int128
     add_executable(SafeIntTest_msvc 
@@ -117,7 +117,7 @@ else()
     ../c_safe_math/safe_math_test_div.cpp
     ../c_safe_math/safe_math_test_mult.cpp
     ../c_safe_math/safe_math_test_sub.cpp
-    ../c_safe_math/compile_test.cpp
+    ../c_safe_math/compile_test.c
     ../AddTestCase.cpp
     ../DivTestCase.cpp
     ../MultTestCase.cpp

--- a/Test/MsvcTest/build_test.cmd
+++ b/Test/MsvcTest/build_test.cmd
@@ -1,0 +1,4 @@
+cmake --build . --config Debug
+cmake --build . --config Release
+ctest -C Debug
+ctest -C Release

--- a/Test/c_safe_math/compile_test.c
+++ b/Test/c_safe_math/compile_test.c
@@ -305,3 +305,146 @@ void check_add_compile(void)
 		ret = check_add_ulonglong_longlong(arg_ullong, arg_llong, &arg_ullong);
 		ret = check_add_ulonglong_ulonglong(arg_ullong, arg_ullong, &arg_ullong);
 }
+
+void safe_mul_compile(void)
+{
+	int ret_int;
+	unsigned int ret_uint;
+	long ret_long;
+	unsigned long ret_ulong;
+	long long ret_llong;
+	unsigned long long ret_ullong;
+	int arg_int = 1;
+	unsigned int arg_uint = 1;
+	long arg_long = 1;
+	unsigned long arg_ulong = 1;
+	long long arg_llong = 1;
+	unsigned long long arg_ullong = 1;
+
+	ret_int = safe_mul_int_int(arg_int, arg_int);
+	ret_int = safe_mul_int_uint(arg_int, arg_uint);
+	ret_int = safe_mul_int_longlong(arg_int, arg_llong);
+	ret_int = safe_mul_int_ulonglong(arg_int, arg_ullong);
+	ret_uint = safe_mul_uint_int(arg_uint, arg_int);
+	ret_uint = safe_mul_uint_uint(arg_uint, arg_uint);
+	ret_uint = safe_mul_uint_longlong(arg_uint, arg_llong);
+	ret_uint = safe_mul_uint_ulonglong(arg_uint, arg_ullong);
+	ret_int = safe_mul_int_long(arg_int, arg_long);
+	ret_int = safe_mul_int_ulong(arg_int, arg_ulong);
+	ret_uint = safe_mul_uint_long(arg_uint, arg_long);
+	ret_uint = safe_mul_uint_ulong(arg_uint, arg_ulong);
+	ret_long = safe_mul_long_int(arg_long, arg_int);
+	ret_long = safe_mul_long_uint(arg_long, arg_uint);
+	ret_long = safe_mul_long_long(arg_long, arg_long);
+	ret_long = safe_mul_long_ulong(arg_long, arg_ulong);
+	ret_long = safe_mul_long_longlong(arg_long, arg_llong);
+	ret_long = safe_mul_long_ulonglong(arg_long, arg_ullong);
+	ret_ulong = safe_mul_ulong_int(arg_ulong, arg_int);
+	ret_ulong = safe_mul_ulong_uint(arg_ulong, arg_uint);
+	ret_ulong = safe_mul_ulong_long(arg_ulong, arg_long);
+	ret_ulong = safe_mul_ulong_ulong(arg_ulong, arg_ulong);
+	ret_ulong = safe_mul_ulong_longlong(arg_ulong, arg_llong);
+	ret_ulong = safe_mul_ulong_ulonglong(arg_ulong, arg_ullong);
+	ret_llong = safe_mul_longlong_long(arg_llong, arg_long);
+	ret_llong = safe_mul_longlong_ulong(arg_llong, arg_ulong);
+	ret_ullong = safe_mul_ulonglong_long(arg_ullong, arg_long);
+	ret_ullong = safe_mul_ulonglong_ulong(arg_ullong, arg_ulong);
+	ret_int = safe_mul_int_long(arg_int, arg_long);
+	ret_int = safe_mul_int_ulong(arg_int, arg_ulong);
+	ret_uint = safe_mul_uint_long(arg_uint, arg_long);
+	ret_uint = safe_mul_uint_ulong(arg_uint, arg_ulong);
+	ret_long = safe_mul_long_int(arg_long, arg_int);
+	ret_long = safe_mul_long_uint(arg_long, arg_uint);
+	ret_long = safe_mul_long_long(arg_long, arg_long);
+	ret_long = safe_mul_long_ulong(arg_long, arg_ulong);
+	ret_long = safe_mul_long_longlong(arg_long, arg_llong);
+	ret_long = safe_mul_long_ulonglong(arg_long, arg_ullong);
+	ret_ulong = safe_mul_ulong_int(arg_ulong, arg_int);
+	ret_ulong = safe_mul_ulong_uint(arg_ulong, arg_uint);
+	ret_ulong = safe_mul_ulong_long(arg_ulong, arg_long);
+	ret_ulong = safe_mul_ulong_ulong(arg_ulong, arg_ulong);
+	ret_ulong = safe_mul_ulong_longlong(arg_ulong, arg_llong);
+	ret_ulong = safe_mul_ulong_ulonglong(arg_ulong, arg_ullong);
+	ret_llong = safe_mul_longlong_long(arg_llong, arg_long);
+	ret_llong = safe_mul_longlong_ulong(arg_llong, arg_ulong);
+	ret_ullong = safe_mul_ulonglong_long(arg_ullong, arg_long);
+	ret_ullong = safe_mul_ulonglong_ulong(arg_ullong, arg_ulong);
+	ret_llong = safe_mul_longlong_int(arg_llong, arg_int);
+	ret_llong = safe_mul_longlong_uint(arg_llong, arg_uint);
+	ret_llong = safe_mul_longlong_longlong(arg_llong, arg_llong);
+	ret_llong = safe_mul_longlong_ulonglong(arg_llong, arg_ullong);
+	ret_ullong = safe_mul_ulonglong_int(arg_ullong, arg_int);
+	ret_ullong = safe_mul_ulonglong_uint(arg_ullong, arg_uint);
+	ret_ullong = safe_mul_ulonglong_longlong(arg_ullong, arg_llong);
+	ret_ullong = safe_mul_ulonglong_ulonglong(arg_ullong, arg_ullong);
+
+}
+
+void check_mul_compile(void)
+{
+	bool ret;
+	int arg_int = 1;
+	unsigned int arg_uint = 1;
+	long arg_long = 1;
+	unsigned long arg_ulong = 1;
+	long long arg_llong = 1;
+	unsigned long long arg_ullong = 1;
+
+	ret = check_mul_int_int(arg_int, arg_int, &arg_int);
+	ret = check_mul_int_uint(arg_int, arg_uint, &arg_int);
+	ret = check_mul_int_longlong(arg_int, arg_llong, &arg_int);
+	ret = check_mul_int_ulonglong(arg_int, arg_ullong, &arg_int);
+	ret = check_mul_uint_int(arg_uint, arg_int, &arg_uint);
+	ret = check_mul_uint_uint(arg_uint, arg_uint, &arg_uint);
+	ret = check_mul_uint_longlong(arg_uint, arg_llong, &arg_uint);
+	ret = check_mul_uint_ulonglong(arg_uint, arg_ullong, &arg_uint);
+	ret = check_mul_int_long(arg_int, arg_long, &arg_int);
+	ret = check_mul_int_ulong(arg_int, arg_ulong, &arg_int);
+	ret = check_mul_uint_long(arg_uint, arg_long, &arg_uint);
+	ret = check_mul_uint_ulong(arg_uint, arg_ulong, &arg_uint);
+	ret = check_mul_long_int(arg_long, arg_int, &arg_long);
+	ret = check_mul_long_uint(arg_long, arg_uint, &arg_long);
+	ret = check_mul_long_long(arg_long, arg_long, &arg_long);
+	ret = check_mul_long_ulong(arg_long, arg_ulong, &arg_long);
+	ret = check_mul_long_longlong(arg_long, arg_llong, &arg_long);
+	ret = check_mul_long_ulonglong(arg_long, arg_ullong, &arg_long);
+	ret = check_mul_ulong_int(arg_ulong, arg_int, &arg_ulong);
+	ret = check_mul_ulong_uint(arg_ulong, arg_uint, &arg_ulong);
+	ret = check_mul_ulong_long(arg_ulong, arg_long, &arg_ulong);
+	ret = check_mul_ulong_ulong(arg_ulong, arg_ulong, &arg_ulong);
+	ret = check_mul_ulong_longlong(arg_ulong, arg_llong, &arg_ulong);
+	ret = check_mul_ulong_ulonglong(arg_ulong, arg_ullong, &arg_ulong);
+	ret = check_mul_longlong_long(arg_llong, arg_long, &arg_llong);
+	ret = check_mul_longlong_ulong(arg_llong, arg_ulong, &arg_llong);
+	ret = check_mul_ulonglong_long(arg_ullong, arg_long, &arg_ullong);
+	ret = check_mul_ulonglong_ulong(arg_ullong, arg_ulong, &arg_ullong);
+	ret = check_mul_int_long(arg_int, arg_long, &arg_int);
+	ret = check_mul_int_ulong(arg_int, arg_ulong, &arg_int);
+	ret = check_mul_uint_long(arg_uint, arg_long, &arg_uint);
+	ret = check_mul_uint_ulong(arg_uint, arg_ulong, &arg_uint);
+	ret = check_mul_long_int(arg_long, arg_int, &arg_long);
+	ret = check_mul_long_uint(arg_long, arg_uint, &arg_long);
+	ret = check_mul_long_long(arg_long, arg_long, &arg_long);
+	ret = check_mul_long_ulong(arg_long, arg_ulong, &arg_long);
+	ret = check_mul_long_longlong(arg_long, arg_llong, &arg_long);
+	ret = check_mul_long_ulonglong(arg_long, arg_ullong, &arg_long);
+	ret = check_mul_ulong_int(arg_ulong, arg_int, &arg_ulong);
+	ret = check_mul_ulong_uint(arg_ulong, arg_uint, &arg_ulong);
+	ret = check_mul_ulong_long(arg_ulong, arg_long, &arg_ulong);
+	ret = check_mul_ulong_ulong(arg_ulong, arg_ulong, &arg_ulong);
+	ret = check_mul_ulong_longlong(arg_ulong, arg_llong, &arg_ulong);
+	ret = check_mul_ulong_ulonglong(arg_ulong, arg_ullong, &arg_ulong);
+	ret = check_mul_longlong_long(arg_llong, arg_long, &arg_llong);
+	ret = check_mul_longlong_ulong(arg_llong, arg_ulong, &arg_llong);
+	ret = check_mul_ulonglong_long(arg_ullong, arg_long, &arg_ullong);
+	ret = check_mul_ulonglong_ulong(arg_ullong, arg_ulong, &arg_ullong);
+	ret = check_mul_longlong_int(arg_llong, arg_int, &arg_llong);
+	ret = check_mul_longlong_uint(arg_llong, arg_uint, &arg_llong);
+	ret = check_mul_longlong_longlong(arg_llong, arg_llong, &arg_llong);
+	ret = check_mul_longlong_ulonglong(arg_llong, arg_ullong, &arg_llong);
+	ret = check_mul_ulonglong_int(arg_ullong, arg_int, &arg_ullong);
+	ret = check_mul_ulonglong_uint(arg_ullong, arg_uint, &arg_ullong);
+	ret = check_mul_ulonglong_longlong(arg_ullong, arg_llong, &arg_ullong);
+	ret = check_mul_ulonglong_ulonglong(arg_ullong, arg_ullong, &arg_ullong);
+
+}

--- a/Test/c_safe_math/compile_test.c
+++ b/Test/c_safe_math/compile_test.c
@@ -2,6 +2,7 @@
 #pragma warning(disable: 4464 5045) // include path contains .., Qspectre mitigation
 #endif
 
+#include <stdio.h>
 #include "../../safe_math.h"
 
 void safe_cast_compile(void)
@@ -86,6 +87,19 @@ void safe_cast_compile(void)
 	ret_llong = safe_cast_longlong_ulonglong(in_ullong);
 	ret_ullong = safe_cast_ulonglong_longlong(in_llong);
 
+	// quench warnings about unused variables
+	if(ret_char ||
+		ret_schar ||
+		ret_uchar ||
+		ret_short ||
+		ret_ushort ||
+		ret_int ||
+		ret_uint ||
+		ret_long ||
+		ret_ulong ||
+		ret_llong ||
+		ret_ullong)
+		printf(" ");
 }
 
 void check_cast_compile(void)
@@ -162,6 +176,9 @@ void check_cast_compile(void)
 	ret = check_cast_ulong_longlong(in_llong);
 	ret = check_cast_longlong_ulonglong(in_ullong);
 	ret = check_cast_ulonglong_longlong(in_llong);
+
+	if(ret) 
+		printf(" ");
 }
 
 void safe_add_compile(void)
@@ -236,6 +253,14 @@ void safe_add_compile(void)
 	ret_ullong = safe_add_ulonglong_uint(arg_ullong, arg_uint);
 	ret_ullong = safe_add_ulonglong_longlong(arg_ullong, arg_llong);
 	ret_ullong = safe_add_ulonglong_ulonglong(arg_ullong, arg_ullong);
+
+	if(ret_int ||
+		ret_uint ||
+		ret_long ||
+		ret_ulong ||
+		ret_llong ||
+		ret_ullong) printf(" ");
+
 }
 
 void check_add_compile(void)
@@ -378,6 +403,13 @@ void safe_mul_compile(void)
 	ret_ullong = safe_mul_ulonglong_longlong(arg_ullong, arg_llong);
 	ret_ullong = safe_mul_ulonglong_ulonglong(arg_ullong, arg_ullong);
 
+	if(ret_int ||
+		ret_uint ||
+		ret_long ||
+		ret_ulong ||
+		ret_llong ||
+		ret_ullong) printf(" ");
+
 }
 
 void check_mul_compile(void)
@@ -447,4 +479,6 @@ void check_mul_compile(void)
 	ret = check_mul_ulonglong_longlong(arg_ullong, arg_llong, &arg_ullong);
 	ret = check_mul_ulonglong_ulonglong(arg_ullong, arg_ullong, &arg_ullong);
 
+	if(ret)
+		printf(" ");
 }

--- a/Test/c_safe_math/compile_test.c
+++ b/Test/c_safe_math/compile_test.c
@@ -1,0 +1,307 @@
+#if defined _MSC_VER
+#pragma warning(disable: 4464 5045) // include path contains .., Qspectre mitigation
+#endif
+
+#include "../../safe_math.h"
+
+void safe_cast_compile(void)
+{
+	char ret_char;
+	signed char ret_schar;
+	unsigned char ret_uchar;
+	short ret_short;
+	unsigned short ret_ushort;
+	int ret_int;
+	unsigned int ret_uint;
+	long ret_long;
+	unsigned long ret_ulong;
+	long long ret_llong;
+	unsigned long long ret_ullong;
+
+	int in_int = 1;
+	unsigned int in_uint = 1;
+	long in_long = 1;
+	unsigned long in_ulong = 1;
+	long long in_llong = 1;
+	unsigned long long in_ullong = 1;
+
+
+	ret_char = safe_cast_char_int(in_int);
+	ret_char = safe_cast_char_uint(in_uint);
+	ret_char = safe_cast_char_long(in_long);
+	ret_char = safe_cast_char_longlong(in_llong);
+	ret_char = safe_cast_char_ulonglong(in_ullong);
+	ret_char = safe_cast_char_int(in_int);
+	ret_char = safe_cast_char_uint(in_uint);
+
+	ret_schar = safe_cast_schar_int(in_int);
+	ret_schar = safe_cast_schar_uint(in_uint);
+	ret_schar = safe_cast_schar_long(in_long);
+	ret_schar = safe_cast_schar_long(in_long);
+	ret_schar = safe_cast_schar_longlong(in_llong);
+	ret_schar = safe_cast_schar_ulonglong(in_ullong);
+	ret_uchar = safe_cast_uchar_int(in_int);
+	ret_uchar = safe_cast_uchar_uint(in_uint);
+	ret_uchar = safe_cast_uchar_long(in_long);
+	ret_uchar = safe_cast_uchar_long(in_long);
+	ret_uchar = safe_cast_uchar_longlong(in_llong);
+	ret_uchar = safe_cast_uchar_ulonglong(in_ullong);
+	ret_short = safe_cast_short_int(in_int);
+	ret_short = safe_cast_short_uint(in_uint);
+	ret_short = safe_cast_short_long(in_long);
+	ret_short = safe_cast_short_long(in_long);
+	ret_short = safe_cast_short_longlong(in_llong);
+	ret_short = safe_cast_short_ulonglong(in_ullong);
+	ret_ushort = safe_cast_ushort_int(in_int);
+	ret_ushort = safe_cast_ushort_uint(in_uint);
+	ret_ushort = safe_cast_ushort_long(in_long);
+	ret_ushort = safe_cast_ushort_long(in_long);
+	ret_ushort = safe_cast_ushort_longlong(in_llong);
+	ret_ushort = safe_cast_ushort_ulonglong(in_ullong);
+	ret_int = safe_cast_int_uint(in_uint);
+	ret_int = safe_cast_int_long(in_long);
+	ret_int = safe_cast_int_ulong(in_ulong);
+	ret_int = safe_cast_int_ulong(in_ulong);
+	ret_int = safe_cast_int_longlong(in_llong);
+	ret_int = safe_cast_int_ulonglong(in_ullong);
+	ret_uint = safe_cast_uint_int(in_int);
+	ret_uint = safe_cast_uint_long(in_long);
+	ret_uint = safe_cast_uint_ulong(in_ulong);
+	ret_uint = safe_cast_uint_long(in_long);
+	ret_uint = safe_cast_uint_ulong(in_ulong);
+	ret_uint = safe_cast_uint_longlong(in_llong);
+	ret_uint = safe_cast_uint_ulonglong(in_ullong);
+	ret_long = safe_cast_long_ulong(in_ulong);
+	ret_long = safe_cast_long_longlong(in_llong);
+	ret_long = safe_cast_long_ulonglong(in_ullong);
+	ret_ulong = safe_cast_ulong_long(in_long);
+	ret_ulong = safe_cast_ulong_ulonglong(in_ullong);
+	ret_ulong = safe_cast_ulong_longlong(in_llong);
+	ret_long = safe_cast_long_ulong(in_ulong);
+	ret_long = safe_cast_long_longlong(in_llong);
+	ret_long = safe_cast_long_ulonglong(in_ullong);
+	ret_ulong = safe_cast_ulong_long(in_long);
+	ret_ulong = safe_cast_ulong_ulonglong(in_ullong);
+	ret_ulong = safe_cast_ulong_longlong(in_llong);
+	ret_llong = safe_cast_longlong_ulonglong(in_ullong);
+	ret_ullong = safe_cast_ulonglong_longlong(in_llong);
+
+}
+
+void check_cast_compile(void)
+{
+	int ret;
+	int in_int = 1;
+	unsigned int in_uint = 1;
+	long in_long = 1;
+	unsigned long in_ulong = 1;
+	long long in_llong = 1;
+	unsigned long long in_ullong = 1;
+
+	ret = check_cast_char_int(in_int);
+	ret = check_cast_char_uint(in_uint);
+	ret = check_cast_char_long(in_long);
+	ret = check_cast_char_long(in_long);
+	ret = check_cast_char_longlong(in_llong);
+	ret = check_cast_char_ulonglong(in_ullong);
+	ret = check_cast_char_int(in_int);
+	ret = check_cast_char_uint(in_uint);
+	ret = check_cast_char_long(in_long);
+	ret = check_cast_char_long(in_long);
+	ret = check_cast_char_longlong(in_llong);
+	ret = check_cast_char_ulonglong(in_ullong);
+	ret = check_cast_schar_int(in_int);
+	ret = check_cast_schar_uint(in_uint);
+	ret = check_cast_schar_long(in_long);
+	ret = check_cast_schar_long(in_long);
+	ret = check_cast_schar_longlong(in_llong);
+	ret = check_cast_schar_ulonglong(in_ullong);
+	ret = check_cast_uchar_int(in_int);
+	ret = check_cast_uchar_uint(in_uint);
+	ret = check_cast_uchar_long(in_long);
+	ret = check_cast_uchar_long(in_long);
+	ret = check_cast_uchar_longlong(in_llong);
+	ret = check_cast_uchar_ulonglong(in_ullong);
+	ret = check_cast_short_int(in_int);
+	ret = check_cast_short_uint(in_uint);
+	ret = check_cast_short_long(in_long);
+	ret = check_cast_short_long(in_long);
+	ret = check_cast_short_longlong(in_llong);
+	ret = check_cast_short_ulonglong(in_ullong);
+	ret = check_cast_ushort_int(in_int);
+	ret = check_cast_ushort_uint(in_uint);
+	ret = check_cast_ushort_long(in_long);
+	ret = check_cast_ushort_long(in_long);
+	ret = check_cast_ushort_longlong(in_llong);
+	ret = check_cast_ushort_ulonglong(in_ullong);
+	ret = check_cast_int_uint(in_uint);
+	ret = check_cast_int_long(in_long);
+	ret = check_cast_int_ulong(in_ulong);
+	ret = check_cast_int_long(in_long);
+	ret = check_cast_int_ulong(in_ulong);
+	ret = check_cast_int_longlong(in_llong);
+	ret = check_cast_int_ulonglong(in_ullong);
+	ret = check_cast_uint_int(in_int);
+	ret = check_cast_uint_long(in_long);
+	ret = check_cast_uint_ulong(in_ulong);
+	ret = check_cast_uint_long(in_long);
+	ret = check_cast_uint_ulong(in_ulong);
+	ret = check_cast_uint_longlong(in_llong);
+	ret = check_cast_uint_ulonglong(in_ullong);
+	ret = check_cast_long_ulong(in_ulong);
+	ret = check_cast_long_longlong(in_llong);
+	ret = check_cast_long_ulonglong(in_ullong);
+	ret = check_cast_ulong_long(in_long);
+	ret = check_cast_ulong_ulonglong(in_ullong);
+	ret = check_cast_ulong_longlong(in_ullong);
+	ret = check_cast_long_ulong(in_ulong);
+	ret = check_cast_long_longlong(in_llong);
+	ret = check_cast_long_ulonglong(in_ullong);
+	ret = check_cast_ulong_long(in_long);
+	ret = check_cast_ulong_ulonglong(in_ullong);
+	ret = check_cast_ulong_longlong(in_llong);
+	ret = check_cast_longlong_ulonglong(in_ullong);
+	ret = check_cast_ulonglong_longlong(in_llong);
+}
+
+void safe_add_compile(void)
+{
+	int ret_int;
+	unsigned int ret_uint;
+	long ret_long;
+	unsigned long ret_ulong;
+	long long ret_llong;
+	unsigned long long ret_ullong;
+
+	int arg_int = 1;
+	unsigned int arg_uint = 1;
+	long arg_long = 1;
+	unsigned long arg_ulong = 1;
+	long long arg_llong = 1;
+	unsigned long long arg_ullong = 1;
+
+	ret_int = safe_add_int_int(arg_int, arg_int);
+	ret_int = safe_add_int_uint(arg_int, arg_uint);
+	ret_int = safe_add_int_longlong(arg_int, arg_llong);
+	ret_int = safe_add_int_ulonglong(arg_int, arg_ullong);
+	ret_uint = safe_add_uint_int(arg_uint, arg_int);
+	ret_uint = safe_add_uint_uint(arg_uint, arg_uint);
+	ret_uint = safe_add_uint_longlong(arg_uint, arg_llong);
+	ret_uint = safe_add_uint_ulonglong(arg_uint, arg_ullong);
+	ret_int = safe_add_int_long(arg_int, arg_long);
+	ret_int = safe_add_int_ulong(arg_int, arg_ulong);
+	ret_uint = safe_add_uint_long(arg_uint, arg_long);
+	ret_uint = safe_add_uint_ulong(arg_uint, arg_ulong);
+	ret_long = safe_add_long_int(arg_long, arg_int);
+	ret_long = safe_add_long_uint(arg_long, arg_uint);
+	ret_long = safe_add_long_long(arg_long, arg_long);
+	ret_long = safe_add_long_ulong(arg_long, arg_ulong);
+	ret_long = safe_add_long_longlong(arg_long, arg_llong);
+	ret_long = safe_add_long_ulonglong(arg_long, arg_ullong);
+	ret_ulong = safe_add_ulong_int(arg_ulong, arg_int);
+	ret_ulong = safe_add_ulong_uint(arg_ulong, arg_uint);
+	ret_ulong = safe_add_ulong_long(arg_ulong, arg_long);
+	ret_ulong = safe_add_ulong_ulong(arg_ulong, arg_ulong);
+	ret_ulong = safe_add_ulong_longlong(arg_ulong, arg_llong);
+	ret_ulong = safe_add_ulong_ulonglong(arg_ulong, arg_ullong);
+	ret_llong = safe_add_longlong_long(arg_llong, arg_long);
+	ret_llong = safe_add_longlong_ulong(arg_llong, arg_ulong);
+	ret_ullong = safe_add_ulonglong_long(arg_ullong, arg_long);
+	ret_ullong = safe_add_ulonglong_ulong(arg_ullong, arg_ulong);
+	ret_int = safe_add_int_long(arg_int, arg_long);
+	ret_int = safe_add_int_ulong(arg_int, arg_ulong);
+	ret_uint = safe_add_uint_long(arg_uint, arg_long);
+	ret_uint = safe_add_uint_ulong(arg_uint, arg_ulong);
+	ret_long = safe_add_long_int(arg_long, arg_int);
+	ret_long = safe_add_long_uint(arg_long, arg_uint);
+	ret_long = safe_add_long_long(arg_long, arg_long);
+	ret_long = safe_add_long_ulong(arg_long, arg_ulong);
+	ret_long = safe_add_long_longlong(arg_long, arg_llong);
+	ret_long = safe_add_long_ulonglong(arg_long, arg_ullong);
+	ret_ulong = safe_add_ulong_int(arg_ulong, arg_int);
+	ret_ulong = safe_add_ulong_uint(arg_ulong, arg_uint);
+	ret_ulong = safe_add_ulong_long(arg_ulong, arg_long);
+	ret_ulong = safe_add_ulong_ulong(arg_ulong, arg_ulong);
+	ret_ulong = safe_add_ulong_longlong(arg_ulong, arg_llong);
+	ret_ulong = safe_add_ulong_ulonglong(arg_ulong, arg_ullong);
+	ret_llong = safe_add_longlong_long(arg_llong, arg_long);
+	ret_llong = safe_add_longlong_ulong(arg_llong, arg_ulong);
+	ret_ullong = safe_add_ulonglong_long(arg_ullong, arg_long);
+	ret_ullong = safe_add_ulonglong_ulong(arg_ullong, arg_ulong);
+	ret_llong = safe_add_longlong_int(arg_llong, arg_int);
+	ret_llong = safe_add_longlong_uint(arg_llong, arg_uint);
+	ret_llong = safe_add_longlong_longlong(arg_llong, arg_llong);
+	ret_llong = safe_add_longlong_ulonglong(arg_llong, arg_ullong);
+	ret_ullong = safe_add_ulonglong_int(arg_ullong, arg_int);
+	ret_ullong = safe_add_ulonglong_uint(arg_ullong, arg_uint);
+	ret_ullong = safe_add_ulonglong_longlong(arg_ullong, arg_llong);
+	ret_ullong = safe_add_ulonglong_ulonglong(arg_ullong, arg_ullong);
+}
+
+void check_add_compile(void)
+{
+	bool ret;
+	int arg_int = 1;
+	unsigned int arg_uint = 1;
+	long arg_long = 1;
+	unsigned long arg_ulong = 1;
+	long long arg_llong = 1;
+	unsigned long long arg_ullong = 1;
+
+		ret = check_add_int_int(arg_int, arg_int, &arg_int);
+		ret = check_add_int_uint(arg_int, arg_uint, &arg_int);
+		ret = check_add_int_longlong(arg_int, arg_llong, &arg_int);
+		ret = check_add_int_ulonglong(arg_int, arg_ullong, &arg_int);
+		ret = check_add_uint_int(arg_uint, arg_int, &arg_uint);
+		ret = check_add_uint_uint(arg_uint, arg_uint, &arg_uint);
+		ret = check_add_uint_longlong(arg_uint, arg_llong, &arg_uint);
+		ret = check_add_uint_ulonglong(arg_uint, arg_ullong, &arg_uint);
+		ret = check_add_int_long(arg_int, arg_long, &arg_int);
+		ret = check_add_int_ulong(arg_int, arg_ulong, &arg_int);
+		ret = check_add_uint_long(arg_uint, arg_long, &arg_uint);
+		ret = check_add_uint_ulong(arg_uint, arg_ulong, &arg_uint);
+		ret = check_add_long_int(arg_long, arg_int, &arg_long);
+		ret = check_add_long_uint(arg_long, arg_uint, &arg_long);
+		ret = check_add_long_long(arg_long, arg_long, &arg_long);
+		ret = check_add_long_ulong(arg_long, arg_ulong, &arg_long);
+		ret = check_add_long_longlong(arg_long, arg_llong, &arg_long);
+		ret = check_add_long_ulonglong(arg_long, arg_ullong, &arg_long);
+		ret = check_add_ulong_int(arg_ulong, arg_int, &arg_ulong);
+		ret = check_add_ulong_uint(arg_ulong, arg_uint, &arg_ulong);
+		ret = check_add_ulong_long(arg_ulong, arg_long, &arg_ulong);
+		ret = check_add_ulong_ulong(arg_ulong, arg_ulong, &arg_ulong);
+		ret = check_add_ulong_longlong(arg_ulong, arg_llong, &arg_ulong);
+		ret = check_add_ulong_ulonglong(arg_ulong, arg_ullong, &arg_ulong);
+		ret = check_add_longlong_long(arg_llong, arg_long, &arg_llong);
+		ret = check_add_longlong_ulong(arg_llong, arg_ulong, &arg_llong);
+		ret = check_add_ulonglong_long(arg_ullong, arg_long, &arg_ullong);
+		ret = check_add_ulonglong_ulong(arg_ullong, arg_ulong, &arg_ullong);
+		ret = check_add_int_long(arg_int, arg_long, &arg_int);
+		ret = check_add_int_ulong(arg_int, arg_ulong, &arg_int);
+		ret = check_add_uint_long(arg_uint, arg_long, &arg_uint);
+		ret = check_add_uint_ulong(arg_uint, arg_ulong, &arg_uint);
+		ret = check_add_long_int(arg_long, arg_int, &arg_long);
+		ret = check_add_long_uint(arg_long, arg_uint, &arg_long);
+		ret = check_add_long_long(arg_long, arg_long, &arg_long);
+		ret = check_add_long_ulong(arg_long, arg_ulong, &arg_long);
+		ret = check_add_long_longlong(arg_long, arg_llong, &arg_long);
+		ret = check_add_long_ulonglong(arg_long, arg_ullong, &arg_long);
+		ret = check_add_ulong_int(arg_ulong, arg_int, &arg_ulong);
+		ret = check_add_ulong_uint(arg_ulong, arg_uint, &arg_ulong);
+		ret = check_add_ulong_long(arg_ulong, arg_long, &arg_ulong);
+		ret = check_add_ulong_ulong(arg_ulong, arg_ulong, &arg_ulong);
+		ret = check_add_ulong_longlong(arg_ulong, arg_llong, &arg_ulong);
+		ret = check_add_ulong_ulonglong(arg_ulong, arg_ullong, &arg_ulong);
+		ret = check_add_longlong_long(arg_llong, arg_long, &arg_llong);
+		ret = check_add_longlong_ulong(arg_llong, arg_ulong, &arg_llong);
+		ret = check_add_ulonglong_long(arg_ullong, arg_long, &arg_ullong);
+		ret = check_add_ulonglong_ulong(arg_ullong, arg_ulong, &arg_ullong);
+		ret = check_add_longlong_int(arg_llong, arg_int, &arg_llong);
+		ret = check_add_longlong_uint(arg_llong, arg_uint, &arg_llong);
+		ret = check_add_longlong_longlong(arg_llong, arg_llong, &arg_llong);
+		ret = check_add_longlong_ulonglong(arg_llong, arg_ullong, &arg_llong);
+		ret = check_add_ulonglong_int(arg_ullong, arg_int, &arg_ullong);
+		ret = check_add_ulonglong_uint(arg_ullong, arg_uint, &arg_ullong);
+		ret = check_add_ulonglong_longlong(arg_ullong, arg_llong, &arg_ullong);
+		ret = check_add_ulonglong_ulonglong(arg_ullong, arg_ullong, &arg_ullong);
+}

--- a/Test/c_safe_math/safe_math_test.c
+++ b/Test/c_safe_math/safe_math_test.c
@@ -16,8 +16,8 @@ void sub_test(void);
 
 int main(int argc, char* argv[])
 {
-	argc;
-	argv;
+	(void)argc;
+	(void)argv;
 
 	add_test();
 	mult_test();

--- a/helpfile.md
+++ b/helpfile.md
@@ -19,12 +19,11 @@ Support for constexpr varies with compiler, version of compiler, and the version
 ### Supported C++ Versions
 This library was originally developed under a compiler which only supported the C++98 standard and should theoretically still compile under some very old compilers, assuming that template support was sufficient. Some of the compilers used circa 2003 didn't have enough template support, but hopefully you're not compiling your code with antique unsupported compilers.
 
-Practically, recently supported versions of gcc and clang require C++11 in order for the standard library headers to compile correctly, which has forced the minimum C++ version for these compilers to be C++11. As explained in Compiler Features, for best results, compile with C++14 or higher.
-
-Note that compilation with C++ versions higher than C++14 are not currently part of the test suite, but shouldn't cause issues. If problems do occur when compiling with more recent C++ versions, please file an issue on GitHub.
+Note that compilation with C++ versions higher than C++17 are not currently part of the test suite, but shouldn't cause issues. If problems do occur when compiling with more recent C++ versions, please file an issue on GitHub.
 
 ### Disabling Exceptions
 Some environments do not support exceptions. The library will attempt to detect whether exceptions are enabled and if not enabled, will by default use the InvalidParameterExceptionHandler. The InvalidParameterExceptionHandler calls __failfast when compiled with the Microsoft Visual Studio Compiler, and calls abort() otherwise. If you would prefer some other mechanism, see User-supplied Exceptions.
+
 ### User-supplied Exceptions
 Replacing the exception handler is a common customization. Many teams have their own well-developed exception classes and would like to use that infrastructure with SafeInt. For example, if you wanted std::runtime_error instead of SafeIntException, create a wrapper header with the following code:
 
@@ -449,8 +448,6 @@ SAFEINT_REMOVE_NOTHROW - the noexcept attribute behavior varies across compilers
 SAFEINT_HAS_INT128, SAFEINT_USE_INTRINSICS - SafeInt has four approaches to 64-bit multiplication - upcast to int128, intrinsics on the Visual Studio compiler with x64 code, builtin functions on gcc and clang, and if all else fails, just do the math. If you would like to force an approach to this, these defines will allow you to that.
 
 SAFEINT_ASSERT - SafeInt will assert various cases that might represent either implementation-dependent or behavior that should get inspected. The default is to use assert(), but you may replace this if your code base has a different set of assert functions.
-
-VISUAL_STUDIO_SAFEINT_COMPAT - there is a very old version of SafeInt that was shipped with Visual Studio, and never updated. It uses the msl::utilities namespace, and it is possible that references to these namespaces have leaked out into your code. If so, define this and you'll have an easier time porting. It is recommended that you just go fix these references, as compatibility hasn't been tested recently, and this will eventually get deprecated.
 
 SAFEINT_ASSERT_ON_EXCEPTION - defining this will cause an assert to be called before an exception is thrown, which may make issues easier to debug.
 

--- a/safe_math.h
+++ b/safe_math.h
@@ -226,102 +226,172 @@ extern char __CHECK_INT_IS_32__[1 / ((sizeof(int) - 4) ? 0 : 1)];
 inline char safe_cast_char_int(int in) { return safe_cast_int8_int32(in); }
 inline char safe_cast_char_uint(unsigned int in) { return safe_cast_int8_uint32(in); }
 
+inline int check_cast_char_int(int in) { return safe_cast_int8_int32(in); }
+inline int check_cast_char_uint(unsigned int in) { return safe_cast_int8_uint32(in); }
+
 #if SAFE_MATH_LONG == 64
 inline char safe_cast_char_long(long in) { return safe_cast_int8_int64(in); }
+inline int check_cast_char_long(long in) { return check_cast_int8_int64(in); }
 #else
 inline char safe_cast_char_long(long in) { return safe_cast_int8_int32(in); }
+inline int check_cast_char_long(long in) { return check_cast_int8_int32(in); }
 #endif
 
 inline char safe_cast_char_longlong(long long in) { return safe_cast_int8_int64(in); }
 inline char safe_cast_char_ulonglong(unsigned long long in) { return safe_cast_int8_uint64(in); }
+
+inline int check_cast_char_longlong(long long in) { return check_cast_int8_int64(in); }
+inline int check_cast_char_ulonglong(unsigned long long in) { return check_cast_int8_uint64(in); }
 #else
 inline char safe_cast_char_int(int in) { return safe_cast_uint8_int32(in); }
 inline char safe_cast_char_uint(unsigned int in) { return safe_cast_uint8_uint32(in); }
 
+inline int check_cast_char_int(int in) { return check_cast_uint8_int32(in); }
+inline int check_cast_char_uint(unsigned int in) { return check_cast_uint8_uint32(in); }
+
 #if SAFE_MATH_LONG == 64
 inline char safe_cast_char_long(long in) { return safe_cast_uint8_int64(in); }
+inline int check_cast_char_long(long in) { return check_cast_uint8_int64(in); }
 #else
 inline char safe_cast_char_long(long in) { return safe_cast_uint8_int32(in); }
+inline int check_cast_char_long(long in) { return check_cast_uint8_int32(in); }
 #endif
 
 inline char safe_cast_char_longlong(long long in) { return safe_cast_uint8_int64(in); }
 inline char safe_cast_char_ulonglong(unsigned long long in) { return safe_cast_uint8_uint64(in); }
+
+inline int check_cast_char_longlong(long long in) { return check_cast_uint8_int64(in); }
+inline int check_cast_char_ulonglong(unsigned long long in) { return check_cast_uint8_uint64(in); }
 #endif
 
 // Signed char
 inline signed char safe_cast_schar_int(int in) { return safe_cast_int8_int32(in); }
 inline signed char safe_cast_schar_uint(unsigned int in) { return safe_cast_int8_uint32(in); }
 
+inline int check_cast_schar_int(int in) { return check_cast_int8_int32(in); }
+inline int check_cast_schar_uint(unsigned int in) { return check_cast_int8_uint32(in); }
+
 #if SAFE_MATH_LONG == 64
 inline signed char safe_cast_schar_long(long in) { return safe_cast_int8_int64(in); }
+inline int check_cast_schar_long(long in) { return check_cast_int8_int64(in); }
 #else
 inline signed char safe_cast_schar_long(long in) { return safe_cast_int8_int32(in); }
+inline int check_cast_schar_long(long in) { return check_cast_int8_int32(in); }
 #endif
 
 inline signed char safe_cast_schar_longlong(long long in) { return safe_cast_int8_int64(in); }
 inline signed char safe_cast_schar_ulonglong(unsigned long long in) { return safe_cast_int8_uint64(in); }
 
+inline int check_cast_schar_longlong(long long in) { return check_cast_int8_int64(in); }
+inline int check_cast_schar_ulonglong(unsigned long long in) { return check_cast_int8_uint64(in); }
+
 // Unsigned char
 inline unsigned char safe_cast_uchar_int(int in) { return safe_cast_uint8_int32(in); }
 inline unsigned char safe_cast_uchar_uint(unsigned int in) { return safe_cast_uint8_uint32(in); }
 
+inline int check_cast_uchar_int(int in) { return check_cast_uint8_int32(in); }
+inline int check_cast_uchar_uint(unsigned int in) { return check_cast_uint8_uint32(in); }
+
 #if SAFE_MATH_LONG == 64
 inline unsigned char safe_cast_uchar_long(long in) { return safe_cast_uint8_int64(in); }
+inline int check_cast_uchar_long(long in) { return check_cast_uint8_int64(in); }
 #else
 inline unsigned char safe_cast_uchar_long(long in) { return safe_cast_uint8_int32(in); }
+inline int check_cast_uchar_long(long in) { return check_cast_uint8_int32(in); }
 #endif
 
 inline unsigned char safe_cast_uchar_longlong(long long in) { return safe_cast_uint8_int64(in); }
 inline unsigned char safe_cast_uchar_ulonglong(unsigned long long in) { return safe_cast_uint8_uint64(in); }
 
+inline int check_cast_uchar_longlong(long long in) { return check_cast_uint8_int64(in); }
+inline int check_cast_uchar_ulonglong(unsigned long long in) { return check_cast_uint8_uint64(in); }
+
 // 16-bit signed casting
 inline short safe_cast_short_int(int in) { return safe_cast_int16_int32(in); }
 inline short safe_cast_short_uint(unsigned int in) { return safe_cast_int16_uint32(in); }
+
+inline int check_cast_short_int(int in) { return check_cast_int16_int32(in); }
+inline int check_cast_short_uint(unsigned int in) { return check_cast_int16_uint32(in); }
 #if SAFE_MATH_LONG == 64
 inline short safe_cast_short_long(long in) { return safe_cast_int16_int64(in); }
+inline int check_cast_short_long(long in) { return check_cast_int16_int64(in); }
 #else
 inline short safe_cast_short_long(long in) { return safe_cast_int16_int32(in); }
+inline int check_cast_short_long(long in) { return check_cast_int16_int32(in); }
 #endif
 
 inline short safe_cast_short_longlong(long long in) { return safe_cast_int16_int64(in); }
 inline short safe_cast_short_ulonglong(unsigned long long in) { return safe_cast_int16_uint64(in); }
 
+inline int check_cast_short_longlong(long long in) { return check_cast_int16_int64(in); }
+inline int check_cast_short_ulonglong(unsigned long long in) { return check_cast_int16_uint64(in); }
+
 // 16-bit unsigned casting
 inline unsigned short safe_cast_ushort_int(int in) { return safe_cast_uint16_int32(in); }
 inline unsigned short safe_cast_ushort_uint(unsigned int in) { return safe_cast_uint16_uint32(in); }
+
+inline int check_cast_ushort_int(int in) { return check_cast_uint16_int32(in); }
+inline int check_cast_ushort_uint(unsigned int in) { return check_cast_uint16_uint32(in); }
 #if SAFE_MATH_LONG == 64
 inline unsigned short safe_cast_ushort_long(long in) { return safe_cast_uint16_int64(in); }
+inline int check_cast_ushort_long(long in) { return check_cast_uint16_int64(in); }
 #else
 inline unsigned short safe_cast_ushort_long(long in) { return safe_cast_uint16_int32(in); }
+inline int check_cast_ushort_long(long in) { return check_cast_uint16_int32(in); }
 #endif
 
 inline unsigned short safe_cast_ushort_longlong(long long in) { return safe_cast_uint16_int64(in); }
 inline unsigned short safe_cast_ushort_ulonglong(unsigned long long in) { return safe_cast_uint16_uint64(in); }
 
+inline int check_cast_ushort_longlong(long long in) { return check_cast_uint16_int64(in); }
+inline int check_cast_ushort_ulonglong(unsigned long long in) { return check_cast_uint16_uint64(in); }
+
 // Cast to int
 inline int safe_cast_int_uint(unsigned int in) { return safe_cast_int32_uint32(in); }
+inline int check_cast_int_uint(unsigned int in) { return check_cast_int32_uint32(in); }
+
 #if SAFE_MATH_LONG == 64
 inline int safe_cast_int_long(long in) { return safe_cast_int32_int64(in); }
 inline int safe_cast_int_ulong(unsigned long in) { return safe_cast_int32_uint64(in); }
+
+inline int check_cast_int_long(long in) { return check_cast_int32_int64(in); }
+inline int check_cast_int_ulong(unsigned long in) { return check_cast_int32_uint64(in); }
 #else
+inline int safe_cast_int_long(long in) { return in; }
 inline int safe_cast_int_ulong(unsigned long in) { return safe_cast_int32_uint32(in); }
+
+inline int check_cast_int_long(long in) { (void)in;  return 0; }
+inline int check_cast_int_ulong(unsigned long in) { return check_cast_int32_uint32(in); }
 #endif
 
 inline int safe_cast_int_longlong(long long in) { return safe_cast_int32_int64(in); }
 inline int safe_cast_int_ulonglong(unsigned long long in) { return safe_cast_int32_uint64(in); }
 
+inline int check_cast_int_longlong(long long in) { return check_cast_int32_int64(in); }
+inline int check_cast_int_ulonglong(unsigned long long in) { return check_cast_int32_uint64(in); }
+
 // Cast to unsigned int
 inline unsigned int safe_cast_uint_int(int in) { return safe_cast_uint32_int32(in); }
+inline int check_cast_uint_int(int in) { return check_cast_uint32_int32(in); }
 #if SAFE_MATH_LONG == 64
 inline unsigned int safe_cast_uint_long(long in) { return safe_cast_uint32_int64(in); }
 inline unsigned int safe_cast_uint_ulong(unsigned long in) { return safe_cast_uint32_uint64(in); }
+
+inline int check_cast_uint_long(long in) { return check_cast_uint32_int64(in); }
+inline int check_cast_uint_ulong(unsigned long in) { return check_cast_uint32_uint64(in); }
 #else
 inline unsigned int safe_cast_uint_long(long in) { return safe_cast_uint32_int32(in); }
 inline unsigned int safe_cast_uint_ulong(unsigned long in) { return in; }
+
+inline int check_cast_uint_long(long in) { return check_cast_uint32_int32(in); }
+inline int check_cast_uint_ulong(unsigned long in) { (void)in; return 0; }
 #endif
 
 inline unsigned int safe_cast_uint_longlong(long long in) { return safe_cast_uint32_int64(in); }
 inline unsigned int safe_cast_uint_ulonglong(unsigned long long in) { return safe_cast_uint32_uint64(in); }
+
+inline int check_cast_uint_longlong(long long in) { return check_cast_uint32_int64(in); }
+inline int check_cast_uint_ulonglong(unsigned long long in) { return check_cast_uint32_uint64(in); }
 
 // Cast to long
 // Also have to keep parity in the case of different compilations
@@ -331,22 +401,41 @@ inline long safe_cast_long_ulong(unsigned long in) { return safe_cast_int64_uint
 inline long safe_cast_long_longlong(long long in) { return in; }
 inline long safe_cast_long_ulonglong(unsigned long long in) { return safe_cast_int64_uint64(in); }
 
+inline int check_cast_long_ulong(unsigned long in) { return check_cast_int64_uint64(in); }
+inline int check_cast_long_longlong(long long in) { return 0; }
+inline int check_cast_long_ulonglong(unsigned long long in) { return check_cast_int64_uint64(in); }
+
 inline unsigned long safe_cast_ulong_long(long in) { return safe_cast_uint64_int64(in); }
 inline unsigned long safe_cast_ulong_ulonglong(unsigned long long in) { return in; }
 inline unsigned long safe_cast_ulong_longlong(unsigned long long in) { return in; }
+
+inline int check_cast_ulong_long(long in) { return check_cast_uint64_int64(in); }
+inline int check_cast_ulong_ulonglong(unsigned long long in) { return 0; }
+inline int check_cast_ulong_longlong(unsigned long long in) { return 0; }
 #else
 inline long safe_cast_long_ulong(unsigned long in) { return safe_cast_int32_uint32(in); }
 inline long safe_cast_long_longlong(long long in) { return safe_cast_int32_int64(in); }
 inline long safe_cast_long_ulonglong(unsigned long long in) { return safe_cast_int32_uint64(in); }
 
+inline int check_cast_long_ulong(unsigned long in) { return check_cast_int32_uint32(in); }
+inline int check_cast_long_longlong(long long in) { return check_cast_int32_int64(in); }
+inline int check_cast_long_ulonglong(unsigned long long in) { return check_cast_int32_uint64(in); }
+
 inline unsigned long safe_cast_ulong_long(long in) { return safe_cast_uint32_int32(in); }
 inline unsigned long safe_cast_ulong_ulonglong(unsigned long long in) { return safe_cast_uint32_uint64(in); }
 inline unsigned long safe_cast_ulong_longlong(long long in) { return safe_cast_uint32_int64(in); }
+
+inline int check_cast_ulong_long(long in) { return check_cast_uint32_int32(in); }
+inline int check_cast_ulong_ulonglong(unsigned long long in) { return check_cast_uint32_uint64(in); }
+inline int check_cast_ulong_longlong(long long in) { return check_cast_uint32_int64(in); }
 #endif
 
 // And long long
 inline long long safe_cast_longlong_ulonglong(unsigned long long in) { return safe_cast_int64_uint64(in); }
 inline unsigned long long safe_cast_ulonglong_longlong(long long in) { return safe_cast_uint64_int64(in); }
+
+inline int check_cast_longlong_ulonglong(unsigned long long in) { return check_cast_int64_uint64(in); }
+inline int check_cast_ulonglong_longlong(long long in) { return check_cast_uint64_int64(in); }
 
 // Addition
 inline int safe_add_int_int(int a, int b) { return safe_add_int32_int32(a, b); }
@@ -354,17 +443,33 @@ inline int safe_add_int_uint(int a, unsigned int b) { return safe_add_int32_uint
 inline int safe_add_int_longlong(int a, long long b) { return safe_add_int32_int64(a, b); }
 inline int safe_add_int_ulonglong(int a, unsigned long long b) { return safe_add_int32_uint64(a, b); }
 
+inline bool check_add_int_int(int a, int b, int* ret) { return check_add_int32_int32(a, b, ret); }
+inline bool check_add_int_uint(int a, unsigned int b, int* ret) { return check_add_int32_uint32(a, b, ret); }
+inline bool check_add_int_longlong(int a, long long b, int* ret) { return check_add_int32_int64(a, b, ret); }
+inline bool check_add_int_ulonglong(int a, unsigned long long b, int* ret) { return check_add_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_add_uint_int(unsigned int a, int b) { return safe_add_uint32_int32(a, b); }
 inline unsigned int safe_add_uint_uint(unsigned int a, unsigned int b) { return safe_add_uint32_uint32(a, b); }
 inline unsigned int safe_add_uint_longlong(unsigned int a, long long b) { return safe_add_uint32_int64(a, b); }
 inline unsigned int safe_add_uint_ulonglong(unsigned int a, unsigned long long b) { return safe_add_uint32_uint64(a, b); }
 
+inline bool check_add_uint_int(unsigned int a, int b, unsigned int* ret) { return check_add_uint32_int32(a, b, ret); }
+inline bool check_add_uint_uint(unsigned int a, unsigned int b, unsigned int* ret) { return check_add_uint32_uint32(a, b, ret); }
+inline bool check_add_uint_longlong(unsigned int a, long long b, unsigned int* ret) { return check_add_uint32_int64(a, b, ret); }
+inline bool check_add_uint_ulonglong(unsigned int a, unsigned long long b, unsigned int* ret) { return check_add_uint32_uint64(a, b, ret); }
+
 #if SAFE_MATH_LONG == 64
 inline int safe_add_int_long(int a, long b) { return safe_add_int32_int64(a, b); }
 inline int safe_add_int_ulong(int a, unsigned long b) { return safe_add_int32_uint64(a, b); }
 
+inline bool check_add_int_long(int a, long b, int* ret) { return check_add_int32_int64(a, b, ret); }
+inline bool check_add_int_ulong(int a, unsigned long b, int* ret) { return check_add_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_add_uint_long(unsigned int a, long b) { return safe_add_uint32_int64(a, b); }
 inline unsigned int safe_add_uint_ulong(unsigned int a, unsigned long b) { return safe_add_uint32_uint64(a, b); }
+
+inline bool check_add_uint_long(unsigned int a, long b, unsigned int* ret) { return check_add_uint32_int64(a, b, ret); }
+inline bool check_add_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_add_uint32_uint64(a, b, ret); }
 
 inline long safe_add_long_int(long a, int b) { return safe_add_int64_int32(a, b); }
 inline long safe_add_long_uint(long a, unsigned int b) { return safe_add_int64_uint32(a, b); }
@@ -373,6 +478,13 @@ inline long safe_add_long_ulong(long a, unsigned long b) { return safe_add_int64
 inline long safe_add_long_longlong(long a, long long b) { return safe_add_int64_int64(a, b); }
 inline long safe_add_long_ulonglong(long a, unsigned long long b) { return safe_add_int64_uint64(a, b); }
 
+inline bool check_add_long_int(long a, int b, long* ret) { return check_add_int64_int32(a, b, ret); }
+inline bool check_add_long_uint(long a, unsigned int b, long* ret) { return check_add_int64_uint32(a, b, ret); }
+inline bool check_add_long_long(long a, long b, long* ret) { return check_add_int64_int64(a, b, ret); }
+inline bool check_add_long_ulong(long a, unsigned long b, long* ret) { return check_add_int64_uint64(a, b, ret); }
+inline bool check_add_long_longlong(long a, long long b, long* ret) { return check_add_int64_int64(a, b, ret); }
+inline bool check_add_long_ulonglong(long a, unsigned long long b, long* ret) { return check_add_int64_uint64(a, b, ret); }
+
 inline unsigned long safe_add_ulong_int(unsigned long a, int b) { return safe_add_uint64_int32(a, b); }
 inline unsigned long safe_add_ulong_uint(unsigned long a, unsigned int b) { return safe_add_uint64_uint32(a, b); }
 inline unsigned long safe_add_ulong_long(unsigned long a, long b) { return safe_add_uint64_int64(a, b); }
@@ -380,17 +492,36 @@ inline unsigned long safe_add_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_add_ulong_longlong(unsigned long a, long long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long safe_add_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_add_uint64_uint64(a, b); }
 
+inline bool check_add_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_add_uint64_int32(a, b, ret); }
+inline bool check_add_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_add_uint64_uint32(a, b, ret); }
+inline bool check_add_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_add_uint64_int64(a, b, ret); }
+inline bool check_add_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, ret); }
+inline bool check_add_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_add_uint64_int64(a, b, ret); }
+inline bool check_add_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, ret); }
+
 inline long long safe_add_longlong_long(long long a, long b) { return safe_add_int64_int64(a, b); }
 inline long long safe_add_longlong_ulong(long long a, unsigned long b) { return safe_add_int64_uint64(a, b); }
 
+inline bool check_add_longlong_long(long long a, long b, long long* ret) { return check_add_int64_int64(a, b, ret); }
+inline bool check_add_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_add_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_add_ulonglong_long(unsigned long long a, long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long long safe_add_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_add_uint64_uint64(a, b); }
+
+inline bool check_add_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, ret); }
+inline bool check_add_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, ret); }
 #else
 inline int safe_add_int_long(int a, long b) { return safe_add_int32_int32(a, b); }
 inline int safe_add_int_ulong(int a, unsigned long b) { return safe_add_int32_uint32(a, b); }
 
+inline bool check_add_int_long(int a, long b, int* ret) { return check_add_int32_int32(a, b, ret); }
+inline bool check_add_int_ulong(int a, unsigned long b, int* ret) { return check_add_int32_uint32(a, b, ret); }
+
 inline unsigned int safe_add_uint_long(unsigned int a, long b) { return safe_add_uint32_int32(a, b); }
 inline unsigned int safe_add_uint_ulong(unsigned int a, unsigned long b) { return safe_add_uint32_uint32(a, b); }
+
+inline bool check_add_uint_long(unsigned int a, long b, unsigned int* ret) { return check_add_uint32_int32(a, b, ret); }
+inline bool check_add_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_add_uint32_uint32(a, b, ret); }
 
 inline long safe_add_long_int(long a, int b) { return safe_add_int32_int32(a, b); }
 inline long safe_add_long_uint(long a, unsigned int b) { return safe_add_int32_uint32(a, b); }
@@ -399,6 +530,13 @@ inline long safe_add_long_ulong(long a, unsigned long b) { return safe_add_int32
 inline long safe_add_long_longlong(long a, long long b) { return safe_add_int32_int64(a, b); }
 inline long safe_add_long_ulonglong(long a, unsigned long long b) { return safe_add_int32_uint64(a, b); }
 
+inline bool check_add_long_int(long a, int b, long* ret) { return check_add_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_add_long_uint(long a, unsigned int b, long* ret) { return check_add_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_add_long_long(long a, long b, long* ret) { return check_add_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_add_long_ulong(long a, unsigned long b, long* ret) { return check_add_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_add_long_longlong(long a, long long b, long* ret) { return check_add_int32_int64(a, b, (int32_t*)ret); }
+inline bool check_add_long_ulonglong(long a, unsigned long long b, long* ret) { return check_add_int32_uint64(a, b, (int32_t*)ret); }
+
 inline unsigned long safe_add_ulong_int(unsigned long a, int b) { return safe_add_uint32_int32(a, b); }
 inline unsigned long safe_add_ulong_uint(unsigned long a, unsigned int b) { return safe_add_uint32_uint32(a, b); }
 inline unsigned long safe_add_ulong_long(unsigned long a, long b) { return safe_add_uint32_int32(a, b); }
@@ -406,11 +544,24 @@ inline unsigned long safe_add_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_add_ulong_longlong(unsigned long a, long long b) { return safe_add_uint32_int64(a, b); }
 inline unsigned long safe_add_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_add_uint32_uint64(a, b); }
 
+inline bool check_add_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_add_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_add_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_add_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_add_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_add_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_add_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_add_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_add_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_add_uint32_int64(a, b, (uint32_t*)ret); }
+inline bool check_add_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_add_uint32_uint64(a, b, (uint32_t*)ret); }
+
 inline long long safe_add_longlong_long(long long a, long b) { return safe_add_int64_int32(a, b); }
 inline long long safe_add_longlong_ulong(long long a, unsigned long b) { return safe_add_int64_uint32(a, b); }
 
+inline bool check_add_longlong_long(long long a, long b, long long* ret) { return check_add_int64_int32(a, b, ret); }
+inline bool check_add_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_add_int64_uint32(a, b, ret); }
+
 inline unsigned long long safe_add_ulonglong_long(unsigned long long a, long b) { return safe_add_uint64_int32(a, b); }
 inline unsigned long long safe_add_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_add_uint64_uint32(a, b); }
+
+inline bool check_add_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_add_uint64_int32(a, b, ret); }
+inline bool check_add_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_add_uint64_uint32(a, b, ret); }
 #endif
 
 inline long long safe_add_longlong_int(long long a, int b) { return safe_add_int64_int32(a, b); }
@@ -418,10 +569,20 @@ inline long long safe_add_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_add_longlong_longlong(long long a, long long b) { return safe_add_int64_int64(a, b); }
 inline long long safe_add_longlong_ulonglong(long long a, unsigned long long b) { return safe_add_int64_uint64(a, b); }
 
+inline bool check_add_longlong_int(long long a, int b, long long* ret) { return check_add_int64_int32(a, b, ret); }
+inline bool check_add_longlong_uint(long long a, unsigned int b, long long* ret) { return check_add_int64_uint32(a, b, ret); }
+inline bool check_add_longlong_longlong(long long a, long long b, long long* ret) { return check_add_int64_int64(a, b, ret); }
+inline bool check_add_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_add_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_add_ulonglong_int(unsigned long long a, int b) { return safe_add_uint64_int32(a, b); }
 inline unsigned long long safe_add_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_add_uint64_uint32(a, b); }
 inline unsigned long long safe_add_ulonglong_longlong(unsigned long long a, long long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long long safe_add_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_add_uint64_uint64(a, b); }
+
+inline bool check_add_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_add_uint64_int32(a, b, ret); }
+inline bool check_add_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_add_uint64_uint32(a, b, ret); }
+inline bool check_add_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, ret); }
+inline bool check_add_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, ret); }
 
 // Multiplication
 inline int safe_mul_int_int(int a, int b) { return safe_mul_int32_int32(a, b); }
@@ -429,17 +590,33 @@ inline int safe_mul_int_uint(int a, unsigned int b) { return safe_mul_int32_uint
 inline int safe_mul_int_longlong(int a, long long b) { return safe_mul_int32_int64(a, b); }
 inline int safe_mul_int_ulonglong(int a, unsigned long long b) { return safe_mul_int32_uint64(a, b); }
 
+inline bool check_mul_int_int(int a, int b, int* ret) { return check_mul_int32_int32(a, b, ret); }
+inline bool check_mul_int_uint(int a, unsigned int b, int* ret) { return check_mul_int32_uint32(a, b, ret); }
+inline bool check_mul_int_longlong(int a, long long b, int* ret) { return check_mul_int32_int64(a, b, ret); }
+inline bool check_mul_int_ulonglong(int a, unsigned long long b, int* ret) { return check_mul_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_mul_uint_int(unsigned int a, int b) { return safe_mul_uint32_int32(a, b); }
 inline unsigned int safe_mul_uint_uint(unsigned int a, unsigned int b) { return safe_mul_uint32_uint32(a, b); }
 inline unsigned int safe_mul_uint_longlong(unsigned int a, long long b) { return safe_mul_uint32_int64(a, b); }
 inline unsigned int safe_mul_uint_ulonglong(unsigned int a, unsigned long long b) { return safe_mul_uint32_uint64(a, b); }
 
+inline bool check_mul_uint_int(unsigned int a, int b, unsigned int* ret) { return check_mul_uint32_int32(a, b, ret); }
+inline bool check_mul_uint_uint(unsigned int a, unsigned int b, unsigned int* ret) { return check_mul_uint32_uint32(a, b, ret); }
+inline bool check_mul_uint_longlong(unsigned int a, long long b, unsigned int* ret) { return check_mul_uint32_int64(a, b, ret); }
+inline bool check_mul_uint_ulonglong(unsigned int a, unsigned long long b, unsigned int* ret) { return check_mul_uint32_uint64(a, b, ret); }
+
 #if SAFE_MATH_LONG == 64
 inline int safe_mul_int_long(int a, long b) { return safe_mul_int32_int64(a, b); }
 inline int safe_mul_int_ulong(int a, unsigned long b) { return safe_mul_int32_uint64(a, b); }
 
+inline bool check_mul_int_long(int a, long b, int* ret) { return check_mul_int32_int64(a, b, ret); }
+inline bool check_mul_int_ulong(int a, unsigned long b, int* ret) { return check_mul_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_mul_uint_long(unsigned int a, long b) { return safe_mul_uint32_int64(a, b); }
 inline unsigned int safe_mul_uint_ulong(unsigned int a, unsigned long b) { return safe_mul_uint32_uint64(a, b); }
+
+inline bool check_mul_uint_long(unsigned int a, long b, unsigned int* ret) { return check_mul_uint32_int64(a, b, ret); }
+inline bool check_mul_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_mul_uint32_uint64(a, b, ret); }
 
 inline long safe_mul_long_int(long a, int b) { return safe_mul_int64_int32(a, b); }
 inline long safe_mul_long_uint(long a, unsigned int b) { return safe_mul_int64_uint32(a, b); }
@@ -448,6 +625,13 @@ inline long safe_mul_long_ulong(long a, unsigned long b) { return safe_mul_int64
 inline long safe_mul_long_longlong(long a, long long b) { return safe_mul_int64_int64(a, b); }
 inline long safe_mul_long_ulonglong(long a, unsigned long long b) { return safe_mul_int64_uint64(a, b); }
 
+inline bool check_mul_long_int(long a, int b, long* ret) { return check_mul_int64_int32(a, b, ret); }
+inline bool check_mul_long_uint(long a, unsigned int b, long* ret) { return check_mul_int64_uint32(a, b, ret); }
+inline bool check_mul_long_long(long a, long b, long* ret) { return check_mul_int64_int64(a, b, ret); }
+inline bool check_mul_long_ulong(long a, unsigned long b, long* ret) { return check_mul_int64_uint64(a, b, ret); }
+inline bool check_mul_long_longlong(long a, long long b, long* ret) { return check_mul_int64_int64(a, b, ret); }
+inline bool check_mul_long_ulonglong(long a, unsigned long long b, long* ret) { return check_mul_int64_uint64(a, b, ret); }
+
 inline unsigned long safe_mul_ulong_int(unsigned long a, int b) { return safe_mul_uint64_int32(a, b); }
 inline unsigned long safe_mul_ulong_uint(unsigned long a, unsigned int b) { return safe_mul_uint64_uint32(a, b); }
 inline unsigned long safe_mul_ulong_long(unsigned long a, long b) { return safe_mul_uint64_int64(a, b); }
@@ -455,17 +639,36 @@ inline unsigned long safe_mul_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_mul_ulong_longlong(unsigned long a, long long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long safe_mul_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_mul_uint64_uint64(a, b); }
 
+inline bool check_mul_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_mul_uint64_int32(a, b, ret); }
+inline bool check_mul_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_mul_uint64_uint32(a, b, ret); }
+inline bool check_mul_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, ret); }
+inline bool check_mul_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b, ret); }
+inline bool check_mul_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, ret); }
+inline bool check_mul_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b,ret); }
+
 inline long long safe_mul_longlong_long(long long a, long b) { return safe_mul_int64_int64(a, b); }
 inline long long safe_mul_longlong_ulong(long long a, unsigned long b) { return safe_mul_int64_uint64(a, b); }
 
+inline bool check_mul_longlong_long(long long a, long b, long long* ret) { return check_mul_int64_int64(a, b, ret); }
+inline bool check_mul_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_mul_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_mul_ulonglong_long(unsigned long long a, long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long long safe_mul_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_mul_uint64_uint64(a, b); }
+
+inline bool check_mul_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, ret); }
+inline bool check_mul_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, ret); }
 #else
 inline int safe_mul_int_long(int a, long b) { return safe_mul_int32_int32(a, b); }
 inline int safe_mul_int_ulong(int a, unsigned long b) { return safe_mul_int32_uint32(a, b); }
 
+inline bool check_mul_int_long(int a, long b, int* ret) { return check_mul_int32_int32(a, b, ret); }
+inline bool check_mul_int_ulong(int a, unsigned long b, int* ret) { return check_mul_int32_uint32(a, b, ret); }
+
 inline unsigned int safe_mul_uint_long(unsigned int a, long b) { return safe_mul_uint32_int32(a, b); }
 inline unsigned int safe_mul_uint_ulong(unsigned int a, unsigned long b) { return safe_mul_uint32_uint32(a, b); }
+
+inline bool check_mul_uint_long(unsigned int a, long b, unsigned int* ret) { return check_mul_uint32_int32(a, b, ret); }
+inline bool check_mul_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_mul_uint32_uint32(a, b, ret); }
 
 inline long safe_mul_long_int(long a, int b) { return safe_mul_int32_int32(a, b); }
 inline long safe_mul_long_uint(long a, unsigned int b) { return safe_mul_int32_uint32(a, b); }
@@ -474,6 +677,13 @@ inline long safe_mul_long_ulong(long a, unsigned long b) { return safe_mul_int32
 inline long safe_mul_long_longlong(long a, long long b) { return safe_mul_int32_int64(a, b); }
 inline long safe_mul_long_ulonglong(long a, unsigned long long b) { return safe_mul_int32_uint64(a, b); }
 
+inline bool check_mul_long_int(long a, int b, long* ret) { return check_mul_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_mul_long_uint(long a, unsigned int b, long* ret) { return check_mul_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_mul_long_long(long a, long b, long* ret) { return check_mul_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_mul_long_ulong(long a, unsigned long b, long* ret) { return check_mul_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_mul_long_longlong(long a, long long b, long* ret) { return check_mul_int32_int64(a, b, (int32_t*)ret); }
+inline bool check_mul_long_ulonglong(long a, unsigned long long b, long* ret) { return check_mul_int32_uint64(a, b, (int32_t*)ret); }
+
 inline unsigned long safe_mul_ulong_int(unsigned long a, int b) { return safe_mul_uint32_int32(a, b); }
 inline unsigned long safe_mul_ulong_uint(unsigned long a, unsigned int b) { return safe_mul_uint32_uint32(a, b); }
 inline unsigned long safe_mul_ulong_long(unsigned long a, long b) { return safe_mul_uint32_int32(a, b); }
@@ -481,11 +691,24 @@ inline unsigned long safe_mul_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_mul_ulong_longlong(unsigned long a, long long b) { return safe_mul_uint32_int64(a, b); }
 inline unsigned long safe_mul_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_mul_uint32_uint64(a, b); }
 
+inline bool check_mul_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_mul_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_mul_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_mul_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_mul_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_mul_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_mul_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_mul_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_mul_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_mul_uint32_int64(a, b, (uint32_t*)ret); }
+inline bool check_mul_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_mul_uint32_uint64(a, b, (uint32_t*)ret); }
+
 inline long long safe_mul_longlong_long(long long a, long b) { return safe_mul_int64_int32(a, b); }
 inline long long safe_mul_longlong_ulong(long long a, unsigned long b) { return safe_mul_int64_uint32(a, b); }
 
+inline bool check_mul_longlong_long(long long a, long b, long long* ret) { return check_mul_int64_int32(a, b, ret); }
+inline bool check_mul_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_mul_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_mul_ulonglong_long(unsigned long long a, long b) { return safe_mul_uint64_int32(a, b); }
 inline unsigned long long safe_mul_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_mul_uint64_uint32(a, b); }
+
+inline bool check_mul_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_mul_uint64_int32(a, b, ret); }
+inline bool check_mul_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_mul_uint64_uint32(a, b, ret); }
 #endif
 
 inline long long safe_mul_longlong_int(long long a, int b) { return safe_mul_int64_int32(a, b); }
@@ -493,10 +716,20 @@ inline long long safe_mul_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_mul_longlong_longlong(long long a, long long b) { return safe_mul_int64_int64(a, b); }
 inline long long safe_mul_longlong_ulonglong(long long a, unsigned long long b) { return safe_mul_int64_uint64(a, b); }
 
+inline bool check_mul_longlong_int(long long a, int b, long long* ret) { return check_mul_int64_int32(a, b, ret); }
+inline bool check_mul_longlong_uint(long long a, unsigned int b, long long* ret) { return check_mul_int64_uint32(a, b, ret); }
+inline bool check_mul_longlong_longlong(long long a, long long b, long long* ret) { return check_mul_int64_int64(a, b, ret); }
+inline bool check_mul_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_mul_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_mul_ulonglong_int(unsigned long long a, int b) { return safe_mul_uint64_int32(a, b); }
 inline unsigned long long safe_mul_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_mul_uint64_uint32(a, b); }
 inline unsigned long long safe_mul_ulonglong_longlong(unsigned long long a, long long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long long safe_mul_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_mul_uint64_uint64(a, b); }
+
+inline bool check_mul_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_mul_uint64_int32(a, b, ret); }
+inline bool check_mul_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_mul_uint64_uint32(a, b, ret); }
+inline bool check_mul_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, ret); }
+inline bool check_mul_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, ret); }
 
 // Subtraction
 inline int safe_sub_int_int(int a, int b) { return safe_sub_int32_int32(a, b); }
@@ -504,17 +737,33 @@ inline int safe_sub_int_uint(int a, unsigned int b) { return safe_sub_int32_uint
 inline int safe_sub_int_longlong(int a, long long b) { return safe_sub_int32_int64(a, b); }
 inline int safe_sub_int_ulonglong(int a, unsigned long long b) { return safe_sub_int32_uint64(a, b); }
 
+inline bool check_sub_int_int(int a, int b, int* ret) { return check_sub_int32_int32(a, b, ret); }
+inline bool check_sub_int_uint(int a, unsigned int b, int* ret) { return check_sub_int32_uint32(a, b, ret); }
+inline bool check_sub_int_longlong(int a, long long b, int* ret) { return check_sub_int32_int64(a, b, ret); }
+inline bool check_sub_int_ulonglong(int a, unsigned long long b, int* ret) { return check_sub_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_sub_uint_int(unsigned int a, int b) { return safe_sub_uint32_int32(a, b); }
 inline unsigned int safe_sub_uint_uint(unsigned int a, unsigned int b) { return safe_sub_uint32_uint32(a, b); }
 inline unsigned int safe_sub_uint_longlong(unsigned int a, long long b) { return safe_sub_uint32_int64(a, b); }
 inline unsigned int safe_sub_uint_ulonglong(unsigned int a, unsigned long long b) { return safe_sub_uint32_uint64(a, b); }
 
+inline bool check_sub_uint_int(unsigned int a, int b, unsigned int* ret) { return check_sub_uint32_int32(a, b, ret); }
+inline bool check_sub_uint_uint(unsigned int a, unsigned int b, unsigned int* ret) { return check_sub_uint32_uint32(a, b, ret); }
+inline bool check_sub_uint_longlong(unsigned int a, long long b, unsigned int* ret) { return check_sub_uint32_int64(a, b, ret); }
+inline bool check_sub_uint_ulonglong(unsigned int a, unsigned long long b, unsigned int* ret) { return check_sub_uint32_uint64(a, b, ret); }
+
 #if SAFE_MATH_LONG == 64
 inline int safe_sub_int_long(int a, long b) { return safe_sub_int32_int64(a, b); }
 inline int safe_sub_int_ulong(int a, unsigned long b) { return safe_sub_int32_uint64(a, b); }
 
+inline bool check_sub_int_long(int a, long b, int* ret) { return check_sub_int32_int64(a, b, ret); }
+inline bool check_sub_int_ulong(int a, unsigned long b, int* ret) { return check_sub_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_sub_uint_long(unsigned int a, long b) { return safe_sub_uint32_int64(a, b); }
 inline unsigned int safe_sub_uint_ulong(unsigned int a, unsigned long b) { return safe_sub_uint32_uint64(a, b); }
+
+inline bool check_sub_uint_long(unsigned int a, long b, unsigned int* ret) { return check_sub_uint32_int64(a, b, ret); }
+inline bool check_sub_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_sub_uint32_uint64(a, b, ret); }
 
 inline long safe_sub_long_int(long a, int b) { return safe_sub_int64_int32(a, b); }
 inline long safe_sub_long_uint(long a, unsigned int b) { return safe_sub_int64_uint32(a, b); }
@@ -523,6 +772,13 @@ inline long safe_sub_long_ulong(long a, unsigned long b) { return safe_sub_int64
 inline long safe_sub_long_longlong(long a, long long b) { return safe_sub_int64_int64(a, b); }
 inline long safe_sub_long_ulonglong(long a, unsigned long long b) { return safe_sub_int64_uint64(a, b); }
 
+inline bool check_sub_long_int(long a, int b, long* ret) { return check_sub_int64_int32(a, b, ret); }
+inline bool check_sub_long_uint(long a, unsigned int b, long* ret) { return check_sub_int64_uint32(a, b, ret); }
+inline bool check_sub_long_long(long a, long b, long* ret) { return check_sub_int64_int64(a, b, ret); }
+inline bool check_sub_long_ulong(long a, unsigned long b, long* ret) { return check_sub_int64_uint64(a, b, ret); }
+inline bool check_sub_long_longlong(long a, long long b, long* ret) { return check_sub_int64_int64(a, b, ret); }
+inline bool check_sub_long_ulonglong(long a, unsigned long long b, long* ret) { return check_sub_int64_uint64(a, b, ret); }
+
 inline unsigned long safe_sub_ulong_int(unsigned long a, int b) { return safe_sub_uint64_int32(a, b); }
 inline unsigned long safe_sub_ulong_uint(unsigned long a, unsigned int b) { return safe_sub_uint64_uint32(a, b); }
 inline unsigned long safe_sub_ulong_long(unsigned long a, long b) { return safe_sub_uint64_int64(a, b); }
@@ -530,17 +786,36 @@ inline unsigned long safe_sub_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_sub_ulong_longlong(unsigned long a, long long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long safe_sub_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_sub_uint64_uint64(a, b); }
 
+inline bool check_sub_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_sub_uint64_int32(a, b, ret); }
+inline bool check_sub_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_sub_uint64_uint32(a, b, ret); }
+inline bool check_sub_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, ret); }
+inline bool check_sub_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, ret); }
+inline bool check_sub_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, ret); }
+inline bool check_sub_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, ret); }
+
 inline long long safe_sub_longlong_long(long long a, long b) { return safe_sub_int64_int64(a, b); }
 inline long long safe_sub_longlong_ulong(long long a, unsigned long b) { return safe_sub_int64_uint64(a, b); }
 
+inline bool check_sub_longlong_long(long long a, long b, long long* ret) { return check_sub_int64_int64(a, b, ret); }
+inline bool check_sub_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_sub_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_sub_ulonglong_long(unsigned long long a, long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long long safe_sub_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_sub_uint64_uint64(a, b); }
+
+inline bool check_sub_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, ret); }
+inline bool check_sub_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, ret); }
 #else
 inline int safe_sub_int_long(int a, long b) { return safe_sub_int32_int32(a, b); }
 inline int safe_sub_int_ulong(int a, unsigned long b) { return safe_sub_int32_uint32(a, b); }
 
+inline bool check_sub_int_long(int a, long b, int* ret) { return check_sub_int32_int32(a, b, ret); }
+inline bool check_sub_int_ulong(int a, unsigned long b, int* ret) { return check_sub_int32_uint32(a, b, ret); }
+
 inline unsigned int safe_sub_uint_long(unsigned int a, long b) { return safe_sub_uint32_int32(a, b); }
 inline unsigned int safe_sub_uint_ulong(unsigned int a, unsigned long b) { return safe_sub_uint32_uint32(a, b); }
+
+inline bool check_sub_uint_long(unsigned int a, long b, unsigned int* ret) { return check_sub_uint32_int32(a, b, ret); }
+inline bool check_sub_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_sub_uint32_uint32(a, b, ret); }
 
 inline long safe_sub_long_int(long a, int b) { return safe_sub_int32_int32(a, b); }
 inline long safe_sub_long_uint(long a, unsigned int b) { return safe_sub_int32_uint32(a, b); }
@@ -549,6 +824,13 @@ inline long safe_sub_long_ulong(long a, unsigned long b) { return safe_sub_int32
 inline long safe_sub_long_longlong(long a, long long b) { return safe_sub_int32_int64(a, b); }
 inline long safe_sub_long_ulonglong(long a, unsigned long long b) { return safe_sub_int32_uint64(a, b); }
 
+inline bool check_sub_long_int(long a, int b, long* ret) { return check_sub_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_sub_long_uint(long a, unsigned int b, long* ret) { return check_sub_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_sub_long_long(long a, long b, long* ret) { return check_sub_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_sub_long_ulong(long a, unsigned long b, long* ret) { return check_sub_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_sub_long_longlong(long a, long long b, long* ret) { return check_sub_int32_int64(a, b, (int32_t*)ret); }
+inline bool check_sub_long_ulonglong(long a, unsigned long long b, long* ret) { return check_sub_int32_uint64(a, b, (int32_t*)ret); }
+
 inline unsigned long safe_sub_ulong_int(unsigned long a, int b) { return safe_sub_uint32_int32(a, b); }
 inline unsigned long safe_sub_ulong_uint(unsigned long a, unsigned int b) { return safe_sub_uint32_uint32(a, b); }
 inline unsigned long safe_sub_ulong_long(unsigned long a, long b) { return safe_sub_uint32_int32(a, b); }
@@ -556,11 +838,24 @@ inline unsigned long safe_sub_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_sub_ulong_longlong(unsigned long a, long long b) { return safe_sub_uint32_int64(a, b); }
 inline unsigned long safe_sub_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_sub_uint32_uint64(a, b); }
 
+inline bool check_sub_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_sub_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_sub_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_sub_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_sub_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_sub_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_sub_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_sub_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_sub_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_sub_uint32_int64(a, b, (uint32_t*)ret); }
+inline bool check_sub_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_sub_uint32_uint64(a, b, (uint32_t*)ret); }
+
 inline long long safe_sub_longlong_long(long long a, long b) { return safe_sub_int64_int32(a, b); }
 inline long long safe_sub_longlong_ulong(long long a, unsigned long b) { return safe_sub_int64_uint32(a, b); }
 
+inline bool check_sub_longlong_long(long long a, long b, long long* ret) { return check_sub_int64_int32(a, b, ret); }
+inline bool check_sub_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_sub_int64_uint32(a, b, ret); }
+
 inline unsigned long long safe_sub_ulonglong_long(unsigned long long a, long b) { return safe_sub_uint64_int32(a, b); }
 inline unsigned long long safe_sub_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_sub_uint64_uint32(a, b); }
+
+inline bool check_sub_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_sub_uint64_int32(a, b, ret); }
+inline bool check_sub_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, ret); }
 #endif
 
 inline long long safe_sub_longlong_int(long long a, int b) { return safe_sub_int64_int32(a, b); }
@@ -568,10 +863,20 @@ inline long long safe_sub_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_sub_longlong_longlong(long long a, long long b) { return safe_sub_int64_int64(a, b); }
 inline long long safe_sub_longlong_ulonglong(long long a, unsigned long long b) { return safe_sub_int64_uint64(a, b); }
 
+inline bool check_sub_longlong_int(long long a, int b, long long* ret) { return check_sub_int64_int32(a, b, ret); }
+inline bool check_sub_longlong_uint(long long a, unsigned int b, long long* ret) { return check_sub_int64_uint32(a, b, ret); }
+inline bool check_sub_longlong_longlong(long long a, long long b, long long* ret) { return check_sub_int64_int64(a, b, ret); }
+inline bool check_sub_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_sub_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_sub_ulonglong_int(unsigned long long a, int b) { return safe_sub_uint64_int32(a, b); }
 inline unsigned long long safe_sub_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_sub_uint64_uint32(a, b); }
 inline unsigned long long safe_sub_ulonglong_longlong(unsigned long long a, long long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long long safe_sub_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_sub_uint64_uint64(a, b); }
+
+inline bool check_sub_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_sub_uint64_int32(a, b, ret); }
+inline bool check_sub_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_sub_uint64_uint32(a, b, ret); }
+inline bool check_sub_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, ret); }
+inline bool check_sub_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, ret); }
 
 // Division
 inline int safe_div_int_int(int a, int b) { return safe_div_int32_int32(a, b); }
@@ -579,17 +884,33 @@ inline int safe_div_int_uint(int a, unsigned int b) { return safe_div_int32_uint
 inline int safe_div_int_longlong(int a, long long b) { return safe_div_int32_int64(a, b); }
 inline int safe_div_int_ulonglong(int a, unsigned long long b) { return safe_div_int32_uint64(a, b); }
 
+inline bool check_div_int_int(int a, int b, int* ret) { return check_div_int32_int32(a, b, ret); }
+inline bool check_div_int_uint(int a, unsigned int b, int* ret) { return check_div_int32_uint32(a, b, ret); }
+inline bool check_div_int_longlong(int a, long long b, int* ret) { return check_div_int32_int64(a, b, ret); }
+inline bool check_div_int_ulonglong(int a, unsigned long long b, int* ret) { return check_div_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_div_uint_int(unsigned int a, int b) { return safe_div_uint32_int32(a, b); }
 inline unsigned int safe_div_uint_uint(unsigned int a, unsigned int b) { return safe_div_uint32_uint32(a, b); }
 inline unsigned int safe_div_uint_longlong(unsigned int a, long long b) { return safe_div_uint32_int64(a, b); }
 inline unsigned int safe_div_uint_ulonglong(unsigned int a, unsigned long long b) { return safe_div_uint32_uint64(a, b); }
 
+inline bool check_div_uint_int(unsigned int a, int b, unsigned int* ret) { return check_div_uint32_int32(a, b, ret); }
+inline bool check_div_uint_uint(unsigned int a, unsigned int b, unsigned int* ret) { return check_div_uint32_uint32(a, b, ret); }
+inline bool check_div_uint_longlong(unsigned int a, long long b, unsigned int* ret) { return check_div_uint32_int64(a, b, ret); }
+inline bool check_div_uint_ulonglong(unsigned int a, unsigned long long b, unsigned int* ret) { return check_div_uint32_uint64(a, b, ret); }
+
 #if SAFE_MATH_LONG == 64
 inline int safe_div_int_long(int a, long b) { return safe_div_int32_int64(a, b); }
 inline int safe_div_int_ulong(int a, unsigned long b) { return safe_div_int32_uint64(a, b); }
 
+inline bool check_div_int_long(int a, long b, int* ret) { return check_div_int32_int64(a, b, ret); }
+inline bool check_div_int_ulong(int a, unsigned long b, int* ret) { return check_div_int32_uint64(a, b, ret); }
+
 inline unsigned int safe_div_uint_long(unsigned int a, long b) { return safe_div_uint32_int64(a, b); }
 inline unsigned int safe_div_uint_ulong(unsigned int a, unsigned long b) { return safe_div_uint32_uint64(a, b); }
+
+inline bool check_div_uint_long(unsigned int a, long b, unsigned int* ret) { return check_div_uint32_int64(a, b, ret); }
+inline bool check_div_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_div_uint32_uint64(a, b, ret); }
 
 inline long safe_div_long_int(long a, int b) { return safe_div_int64_int32(a, b); }
 inline long safe_div_long_uint(long a, unsigned int b) { return safe_div_int64_uint32(a, b); }
@@ -598,6 +919,13 @@ inline long safe_div_long_ulong(long a, unsigned long b) { return safe_div_int64
 inline long safe_div_long_longlong(long a, long long b) { return safe_div_int64_int64(a, b); }
 inline long safe_div_long_ulonglong(long a, unsigned long long b) { return safe_div_int64_uint64(a, b); }
 
+inline bool check_div_long_int(long a, int b, long* ret) { return check_div_int64_int32(a, b, ret); }
+inline bool check_div_long_uint(long a, unsigned int b, long* ret) { return check_div_int64_uint32(a, b, ret); }
+inline bool check_div_long_long(long a, long b, long* ret) { return check_div_int64_int64(a, b, ret); }
+inline bool check_div_long_ulong(long a, unsigned long b, long* ret) { return check_div_int64_uint64(a, b, ret); }
+inline bool check_div_long_longlong(long a, long long b, long* ret) { return check_div_int64_int64(a, b, ret); }
+inline bool check_div_long_ulonglong(long a, unsigned long long b, long* ret) { return check_div_int64_uint64(a, b, ret); }
+
 inline unsigned long safe_div_ulong_int(unsigned long a, int b) { return safe_div_uint64_int32(a, b); }
 inline unsigned long safe_div_ulong_uint(unsigned long a, unsigned int b) { return safe_div_uint64_uint32(a, b); }
 inline unsigned long safe_div_ulong_long(unsigned long a, long b) { return safe_div_uint64_int64(a, b); }
@@ -605,17 +933,36 @@ inline unsigned long safe_div_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_div_ulong_longlong(unsigned long a, long long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long safe_div_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_div_uint64_uint64(a, b); }
 
+inline bool check_div_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_div_uint64_int32(a, b, ret); }
+inline bool check_div_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_div_uint64_uint32(a, b, ret); }
+inline bool check_div_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_div_uint64_int64(a, b, ret); }
+inline bool check_div_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, ret); }
+inline bool check_div_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_div_uint64_int64(a, b, ret); }
+inline bool check_div_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, ret); }
+
 inline long long safe_div_longlong_long(long long a, long b) { return safe_div_int64_int64(a, b); }
 inline long long safe_div_longlong_ulong(long long a, unsigned long b) { return safe_div_int64_uint64(a, b); }
 
+inline bool check_div_longlong_long(long long a, long b, long long* ret) { return check_div_int64_int64(a, b, ret); }
+inline bool check_div_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_div_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_div_ulonglong_long(unsigned long long a, long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long long safe_div_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_div_uint64_uint64(a, b); }
+
+inline bool check_div_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, ret); }
+inline bool check_div_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, ret); }
 #else
 inline int safe_div_int_long(int a, long b) { return safe_div_int32_int32(a, b); }
 inline int safe_div_int_ulong(int a, unsigned long b) { return safe_div_int32_uint32(a, b); }
 
+inline bool check_div_int_long(int a, long b, int* ret) { return check_div_int32_int32(a, b, ret); }
+inline bool check_div_int_ulong(int a, unsigned long b, int* ret) { return check_div_int32_uint32(a, b, ret); }
+
 inline unsigned int safe_div_uint_long(unsigned int a, long b) { return safe_div_uint32_int32(a, b); }
 inline unsigned int safe_div_uint_ulong(unsigned int a, unsigned long b) { return safe_div_uint32_uint32(a, b); }
+
+inline bool check_div_uint_long(unsigned int a, long b, unsigned int* ret) { return check_div_uint32_int32(a, b, ret); }
+inline bool check_div_uint_ulong(unsigned int a, unsigned long b, unsigned int* ret) { return check_div_uint32_uint32(a, b, ret); }
 
 inline long safe_div_long_int(long a, int b) { return safe_div_int32_int32(a, b); }
 inline long safe_div_long_uint(long a, unsigned int b) { return safe_div_int32_uint32(a, b); }
@@ -624,6 +971,13 @@ inline long safe_div_long_ulong(long a, unsigned long b) { return safe_div_int32
 inline long safe_div_long_longlong(long a, long long b) { return safe_div_int32_int64(a, b); }
 inline long safe_div_long_ulonglong(long a, unsigned long long b) { return safe_div_int32_uint64(a, b); }
 
+inline bool check_div_long_int(long a, int b, long* ret) { return check_div_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_div_long_uint(long a, unsigned int b, long* ret) { return check_div_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_div_long_long(long a, long b, long* ret) { return check_div_int32_int32(a, b, (int32_t*)ret); }
+inline bool check_div_long_ulong(long a, unsigned long b, long* ret) { return check_div_int32_uint32(a, b, (int32_t*)ret); }
+inline bool check_div_long_longlong(long a, long long b, long* ret) { return check_div_int32_int64(a, b, (int32_t*)ret); }
+inline bool check_div_long_ulonglong(long a, unsigned long long b, long* ret) { return check_div_int32_uint64(a, b, (int32_t*)ret); }
+
 inline unsigned long safe_div_ulong_int(unsigned long a, int b) { return safe_div_uint32_int32(a, b); }
 inline unsigned long safe_div_ulong_uint(unsigned long a, unsigned int b) { return safe_div_uint32_uint32(a, b); }
 inline unsigned long safe_div_ulong_long(unsigned long a, long b) { return safe_div_uint32_int32(a, b); }
@@ -631,11 +985,24 @@ inline unsigned long safe_div_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_div_ulong_longlong(unsigned long a, long long b) { return safe_div_uint32_int64(a, b); }
 inline unsigned long safe_div_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_div_uint32_uint64(a, b); }
 
+inline bool check_div_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_div_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_div_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_div_uint32_uint32(a, b, (uint32_t*)ret); }
+inline bool check_div_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_div_uint32_int32(a, b, (uint32_t*)ret); }
+inline bool check_div_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_div_uint32_uint64(a, b, (uint32_t*)ret); }
+inline bool check_div_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_div_uint32_int64(a, b, (uint32_t*)ret); }
+inline bool check_div_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_div_uint32_uint64(a, b, (uint32_t*)ret); }
+
 inline long long safe_div_longlong_long(long long a, long b) { return safe_div_int64_int32(a, b); }
 inline long long safe_div_longlong_ulong(long long a, unsigned long b) { return safe_div_int64_uint32(a, b); }
 
+inline bool check_div_longlong_long(long long a, long b, long long* ret) { return check_div_int64_int32(a, b, ret); }
+inline bool check_div_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_div_int64_uint32(a, b, ret); }
+
 inline unsigned long long safe_div_ulonglong_long(unsigned long long a, long b) { return safe_div_uint64_int32(a, b); }
 inline unsigned long long safe_div_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_div_uint64_uint32(a, b); }
+
+inline bool check_div_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_div_uint64_int32(a, b, ret); }
+inline bool check_div_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_div_uint64_uint32(a, b, ret); }
 #endif
 
 inline long long safe_div_longlong_int(long long a, int b) { return safe_div_int64_int32(a, b); }
@@ -643,10 +1010,20 @@ inline long long safe_div_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_div_longlong_longlong(long long a, long long b) { return safe_div_int64_int64(a, b); }
 inline long long safe_div_longlong_ulonglong(long long a, unsigned long long b) { return safe_div_int64_uint64(a, b); }
 
+inline bool check_div_longlong_int(long long a, int b, long long* ret) { return check_div_int64_int32(a, b, ret); }
+inline bool check_div_longlong_uint(long long a, unsigned int b, long long* ret) { return check_div_int64_uint32(a, b, ret); }
+inline bool check_div_longlong_longlong(long long a, long long b, long long* ret) { return check_div_int64_int64(a, b, ret); }
+inline bool check_div_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_div_int64_uint64(a, b, ret); }
+
 inline unsigned long long safe_div_ulonglong_int(unsigned long long a, int b) { return safe_div_uint64_int32(a, b); }
 inline unsigned long long safe_div_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_div_uint64_uint32(a, b); }
 inline unsigned long long safe_div_ulonglong_longlong(unsigned long long a, long long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long long safe_div_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_div_uint64_uint64(a, b); }
+
+inline bool check_div_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_div_uint64_int32(a, b, ret); }
+inline bool check_div_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_div_uint64_uint32(a, b, ret); }
+inline bool check_div_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, ret); }
+inline bool check_div_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, ret); }
 
 #ifdef __cplusplus
 }

--- a/safe_math.h
+++ b/safe_math.h
@@ -9,7 +9,9 @@
 #endif
 
 // C wants a prototype, if all warnings enabled
-void safe_math_fail(const char* msg);
+#if !defined SAFE_MATH_FAIL_DEFINED
+static inline void safe_math_fail(const char* msg);
+#endif
 
 #include "safe_math_impl.h"
 
@@ -492,24 +494,24 @@ inline unsigned long safe_add_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_add_ulong_longlong(unsigned long a, long long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long safe_add_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_add_uint64_uint64(a, b); }
 
-inline bool check_add_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_add_uint64_int32(a, b, ret); }
-inline bool check_add_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_add_uint64_uint32(a, b, ret); }
-inline bool check_add_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_add_uint64_int64(a, b, ret); }
-inline bool check_add_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, ret); }
-inline bool check_add_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_add_uint64_int64(a, b, ret); }
-inline bool check_add_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, ret); }
+inline bool check_add_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_add_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_add_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_add_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_add_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_add_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_add_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, (uint64_t*)ret); }
+inline bool check_add_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_add_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_add_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_add_uint64_uint64(a, b, (uint64_t*)ret); }
 
 inline long long safe_add_longlong_long(long long a, long b) { return safe_add_int64_int64(a, b); }
 inline long long safe_add_longlong_ulong(long long a, unsigned long b) { return safe_add_int64_uint64(a, b); }
 
-inline bool check_add_longlong_long(long long a, long b, long long* ret) { return check_add_int64_int64(a, b, ret); }
-inline bool check_add_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_add_int64_uint64(a, b, ret); }
+inline bool check_add_longlong_long(long long a, long b, long long* ret) { return check_add_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_add_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_add_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_add_ulonglong_long(unsigned long long a, long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long long safe_add_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_add_uint64_uint64(a, b); }
 
-inline bool check_add_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, ret); }
-inline bool check_add_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, ret); }
+inline bool check_add_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_add_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, (uint64_t*)ret); }
 #else
 inline int safe_add_int_long(int a, long b) { return safe_add_int32_int32(a, b); }
 inline int safe_add_int_ulong(int a, unsigned long b) { return safe_add_int32_uint32(a, b); }
@@ -569,20 +571,20 @@ inline long long safe_add_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_add_longlong_longlong(long long a, long long b) { return safe_add_int64_int64(a, b); }
 inline long long safe_add_longlong_ulonglong(long long a, unsigned long long b) { return safe_add_int64_uint64(a, b); }
 
-inline bool check_add_longlong_int(long long a, int b, long long* ret) { return check_add_int64_int32(a, b, ret); }
-inline bool check_add_longlong_uint(long long a, unsigned int b, long long* ret) { return check_add_int64_uint32(a, b, ret); }
-inline bool check_add_longlong_longlong(long long a, long long b, long long* ret) { return check_add_int64_int64(a, b, ret); }
-inline bool check_add_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_add_int64_uint64(a, b, ret); }
+inline bool check_add_longlong_int(long long a, int b, long long* ret) { return check_add_int64_int32(a, b, (int64_t*)ret); }
+inline bool check_add_longlong_uint(long long a, unsigned int b, long long* ret) { return check_add_int64_uint32(a, b, (int64_t*)ret); }
+inline bool check_add_longlong_longlong(long long a, long long b, long long* ret) { return check_add_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_add_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_add_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_add_ulonglong_int(unsigned long long a, int b) { return safe_add_uint64_int32(a, b); }
 inline unsigned long long safe_add_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_add_uint64_uint32(a, b); }
 inline unsigned long long safe_add_ulonglong_longlong(unsigned long long a, long long b) { return safe_add_uint64_int64(a, b); }
 inline unsigned long long safe_add_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_add_uint64_uint64(a, b); }
 
-inline bool check_add_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_add_uint64_int32(a, b, ret); }
-inline bool check_add_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_add_uint64_uint32(a, b, ret); }
-inline bool check_add_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, ret); }
-inline bool check_add_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, ret); }
+inline bool check_add_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_add_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_add_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_add_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_add_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_add_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_add_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_add_uint64_uint64(a, b, (uint64_t*)ret); }
 
 // Multiplication
 inline int safe_mul_int_int(int a, int b) { return safe_mul_int32_int32(a, b); }
@@ -639,24 +641,24 @@ inline unsigned long safe_mul_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_mul_ulong_longlong(unsigned long a, long long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long safe_mul_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_mul_uint64_uint64(a, b); }
 
-inline bool check_mul_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_mul_uint64_int32(a, b, ret); }
-inline bool check_mul_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_mul_uint64_uint32(a, b, ret); }
-inline bool check_mul_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, ret); }
-inline bool check_mul_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b, ret); }
-inline bool check_mul_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, ret); }
-inline bool check_mul_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b,ret); }
+inline bool check_mul_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_mul_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_mul_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_mul_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_mul_uint64_uint64(a, b,(uint64_t*)ret); }
 
 inline long long safe_mul_longlong_long(long long a, long b) { return safe_mul_int64_int64(a, b); }
 inline long long safe_mul_longlong_ulong(long long a, unsigned long b) { return safe_mul_int64_uint64(a, b); }
 
-inline bool check_mul_longlong_long(long long a, long b, long long* ret) { return check_mul_int64_int64(a, b, ret); }
-inline bool check_mul_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_mul_int64_uint64(a, b, ret); }
+inline bool check_mul_longlong_long(long long a, long b, long long* ret) { return check_mul_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_mul_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_mul_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_mul_ulonglong_long(unsigned long long a, long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long long safe_mul_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_mul_uint64_uint64(a, b); }
 
-inline bool check_mul_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, ret); }
-inline bool check_mul_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, ret); }
+inline bool check_mul_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, (uint64_t*)ret); }
 #else
 inline int safe_mul_int_long(int a, long b) { return safe_mul_int32_int32(a, b); }
 inline int safe_mul_int_ulong(int a, unsigned long b) { return safe_mul_int32_uint32(a, b); }
@@ -716,20 +718,20 @@ inline long long safe_mul_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_mul_longlong_longlong(long long a, long long b) { return safe_mul_int64_int64(a, b); }
 inline long long safe_mul_longlong_ulonglong(long long a, unsigned long long b) { return safe_mul_int64_uint64(a, b); }
 
-inline bool check_mul_longlong_int(long long a, int b, long long* ret) { return check_mul_int64_int32(a, b, ret); }
-inline bool check_mul_longlong_uint(long long a, unsigned int b, long long* ret) { return check_mul_int64_uint32(a, b, ret); }
-inline bool check_mul_longlong_longlong(long long a, long long b, long long* ret) { return check_mul_int64_int64(a, b, ret); }
-inline bool check_mul_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_mul_int64_uint64(a, b, ret); }
+inline bool check_mul_longlong_int(long long a, int b, long long* ret) { return check_mul_int64_int32(a, b, (int64_t*)ret); }
+inline bool check_mul_longlong_uint(long long a, unsigned int b, long long* ret) { return check_mul_int64_uint32(a, b, (int64_t*)ret); }
+inline bool check_mul_longlong_longlong(long long a, long long b, long long* ret) { return check_mul_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_mul_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_mul_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_mul_ulonglong_int(unsigned long long a, int b) { return safe_mul_uint64_int32(a, b); }
 inline unsigned long long safe_mul_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_mul_uint64_uint32(a, b); }
 inline unsigned long long safe_mul_ulonglong_longlong(unsigned long long a, long long b) { return safe_mul_uint64_int64(a, b); }
 inline unsigned long long safe_mul_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_mul_uint64_uint64(a, b); }
 
-inline bool check_mul_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_mul_uint64_int32(a, b, ret); }
-inline bool check_mul_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_mul_uint64_uint32(a, b, ret); }
-inline bool check_mul_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, ret); }
-inline bool check_mul_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, ret); }
+inline bool check_mul_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_mul_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_mul_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_mul_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_mul_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_mul_uint64_uint64(a, b, (uint64_t*)ret); }
 
 // Subtraction
 inline int safe_sub_int_int(int a, int b) { return safe_sub_int32_int32(a, b); }
@@ -786,24 +788,24 @@ inline unsigned long safe_sub_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_sub_ulong_longlong(unsigned long a, long long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long safe_sub_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_sub_uint64_uint64(a, b); }
 
-inline bool check_sub_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_sub_uint64_int32(a, b, ret); }
-inline bool check_sub_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_sub_uint64_uint32(a, b, ret); }
-inline bool check_sub_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, ret); }
-inline bool check_sub_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, ret); }
-inline bool check_sub_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, ret); }
-inline bool check_sub_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, ret); }
+inline bool check_sub_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_sub_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_sub_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_sub_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_sub_uint64_uint64(a, b, (uint64_t*)ret); }
 
 inline long long safe_sub_longlong_long(long long a, long b) { return safe_sub_int64_int64(a, b); }
 inline long long safe_sub_longlong_ulong(long long a, unsigned long b) { return safe_sub_int64_uint64(a, b); }
 
-inline bool check_sub_longlong_long(long long a, long b, long long* ret) { return check_sub_int64_int64(a, b, ret); }
-inline bool check_sub_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_sub_int64_uint64(a, b, ret); }
+inline bool check_sub_longlong_long(long long a, long b, long long* ret) { return check_sub_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_sub_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_sub_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_sub_ulonglong_long(unsigned long long a, long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long long safe_sub_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_sub_uint64_uint64(a, b); }
 
-inline bool check_sub_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, ret); }
-inline bool check_sub_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, ret); }
+inline bool check_sub_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, (uint64_t*)ret); }
 #else
 inline int safe_sub_int_long(int a, long b) { return safe_sub_int32_int32(a, b); }
 inline int safe_sub_int_ulong(int a, unsigned long b) { return safe_sub_int32_uint32(a, b); }
@@ -863,20 +865,20 @@ inline long long safe_sub_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_sub_longlong_longlong(long long a, long long b) { return safe_sub_int64_int64(a, b); }
 inline long long safe_sub_longlong_ulonglong(long long a, unsigned long long b) { return safe_sub_int64_uint64(a, b); }
 
-inline bool check_sub_longlong_int(long long a, int b, long long* ret) { return check_sub_int64_int32(a, b, ret); }
-inline bool check_sub_longlong_uint(long long a, unsigned int b, long long* ret) { return check_sub_int64_uint32(a, b, ret); }
-inline bool check_sub_longlong_longlong(long long a, long long b, long long* ret) { return check_sub_int64_int64(a, b, ret); }
-inline bool check_sub_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_sub_int64_uint64(a, b, ret); }
+inline bool check_sub_longlong_int(long long a, int b, long long* ret) { return check_sub_int64_int32(a, b, (int64_t*)ret); }
+inline bool check_sub_longlong_uint(long long a, unsigned int b, long long* ret) { return check_sub_int64_uint32(a, b, (int64_t*)ret); }
+inline bool check_sub_longlong_longlong(long long a, long long b, long long* ret) { return check_sub_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_sub_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_sub_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_sub_ulonglong_int(unsigned long long a, int b) { return safe_sub_uint64_int32(a, b); }
 inline unsigned long long safe_sub_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_sub_uint64_uint32(a, b); }
 inline unsigned long long safe_sub_ulonglong_longlong(unsigned long long a, long long b) { return safe_sub_uint64_int64(a, b); }
 inline unsigned long long safe_sub_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_sub_uint64_uint64(a, b); }
 
-inline bool check_sub_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_sub_uint64_int32(a, b, ret); }
-inline bool check_sub_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_sub_uint64_uint32(a, b, ret); }
-inline bool check_sub_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, ret); }
-inline bool check_sub_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, ret); }
+inline bool check_sub_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_sub_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_sub_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_sub_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_sub_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_sub_uint64_uint64(a, b, (uint64_t*)ret); }
 
 // Division
 inline int safe_div_int_int(int a, int b) { return safe_div_int32_int32(a, b); }
@@ -933,24 +935,24 @@ inline unsigned long safe_div_ulong_ulong(unsigned long a, unsigned long b) { re
 inline unsigned long safe_div_ulong_longlong(unsigned long a, long long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long safe_div_ulong_ulonglong(unsigned long a, unsigned long long b) { return safe_div_uint64_uint64(a, b); }
 
-inline bool check_div_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_div_uint64_int32(a, b, ret); }
-inline bool check_div_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_div_uint64_uint32(a, b, ret); }
-inline bool check_div_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_div_uint64_int64(a, b, ret); }
-inline bool check_div_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, ret); }
-inline bool check_div_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_div_uint64_int64(a, b, ret); }
-inline bool check_div_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, ret); }
+inline bool check_div_ulong_int(unsigned long a, int b, unsigned long* ret) { return check_div_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_div_ulong_uint(unsigned long a, unsigned int b, unsigned long* ret) { return check_div_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_div_ulong_long(unsigned long a, long b, unsigned long* ret) { return check_div_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_div_ulong_ulong(unsigned long a, unsigned long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, (uint64_t*)ret); }
+inline bool check_div_ulong_longlong(unsigned long a, long long b, unsigned long* ret) { return check_div_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_div_ulong_ulonglong(unsigned long a, unsigned long long b, unsigned long* ret) { return check_div_uint64_uint64(a, b, (uint64_t*)ret); }
 
 inline long long safe_div_longlong_long(long long a, long b) { return safe_div_int64_int64(a, b); }
 inline long long safe_div_longlong_ulong(long long a, unsigned long b) { return safe_div_int64_uint64(a, b); }
 
-inline bool check_div_longlong_long(long long a, long b, long long* ret) { return check_div_int64_int64(a, b, ret); }
-inline bool check_div_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_div_int64_uint64(a, b, ret); }
+inline bool check_div_longlong_long(long long a, long b, long long* ret) { return check_div_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_div_longlong_ulong(long long a, unsigned long b, long long* ret) { return check_div_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_div_ulonglong_long(unsigned long long a, long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long long safe_div_ulonglong_ulong(unsigned long long a, unsigned long b) { return safe_div_uint64_uint64(a, b); }
 
-inline bool check_div_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, ret); }
-inline bool check_div_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, ret); }
+inline bool check_div_ulonglong_long(unsigned long long a, long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_div_ulonglong_ulong(unsigned long long a, unsigned long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, (uint64_t*)ret); }
 #else
 inline int safe_div_int_long(int a, long b) { return safe_div_int32_int32(a, b); }
 inline int safe_div_int_ulong(int a, unsigned long b) { return safe_div_int32_uint32(a, b); }
@@ -1010,20 +1012,20 @@ inline long long safe_div_longlong_uint(long long a, unsigned int b) { return sa
 inline long long safe_div_longlong_longlong(long long a, long long b) { return safe_div_int64_int64(a, b); }
 inline long long safe_div_longlong_ulonglong(long long a, unsigned long long b) { return safe_div_int64_uint64(a, b); }
 
-inline bool check_div_longlong_int(long long a, int b, long long* ret) { return check_div_int64_int32(a, b, ret); }
-inline bool check_div_longlong_uint(long long a, unsigned int b, long long* ret) { return check_div_int64_uint32(a, b, ret); }
-inline bool check_div_longlong_longlong(long long a, long long b, long long* ret) { return check_div_int64_int64(a, b, ret); }
-inline bool check_div_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_div_int64_uint64(a, b, ret); }
+inline bool check_div_longlong_int(long long a, int b, long long* ret) { return check_div_int64_int32(a, b, (int64_t*)ret); }
+inline bool check_div_longlong_uint(long long a, unsigned int b, long long* ret) { return check_div_int64_uint32(a, b, (int64_t*)ret); }
+inline bool check_div_longlong_longlong(long long a, long long b, long long* ret) { return check_div_int64_int64(a, b, (int64_t*)ret); }
+inline bool check_div_longlong_ulonglong(long long a, unsigned long long b, long long* ret) { return check_div_int64_uint64(a, b, (int64_t*)ret); }
 
 inline unsigned long long safe_div_ulonglong_int(unsigned long long a, int b) { return safe_div_uint64_int32(a, b); }
 inline unsigned long long safe_div_ulonglong_uint(unsigned long long a, unsigned int b) { return safe_div_uint64_uint32(a, b); }
 inline unsigned long long safe_div_ulonglong_longlong(unsigned long long a, long long b) { return safe_div_uint64_int64(a, b); }
 inline unsigned long long safe_div_ulonglong_ulonglong(unsigned long long a, unsigned long long b) { return safe_div_uint64_uint64(a, b); }
 
-inline bool check_div_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_div_uint64_int32(a, b, ret); }
-inline bool check_div_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_div_uint64_uint32(a, b, ret); }
-inline bool check_div_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, ret); }
-inline bool check_div_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, ret); }
+inline bool check_div_ulonglong_int(unsigned long long a, int b, unsigned long long* ret) { return check_div_uint64_int32(a, b, (uint64_t*)ret); }
+inline bool check_div_ulonglong_uint(unsigned long long a, unsigned int b, unsigned long long* ret) { return check_div_uint64_uint32(a, b, (uint64_t*)ret); }
+inline bool check_div_ulonglong_longlong(unsigned long long a, long long b, unsigned long long* ret) { return check_div_uint64_int64(a, b, (uint64_t*)ret); }
+inline bool check_div_ulonglong_ulonglong(unsigned long long a, unsigned long long b, unsigned long long* ret) { return check_div_uint64_uint64(a, b, (uint64_t*)ret); }
 
 #ifdef __cplusplus
 }

--- a/safe_math.h
+++ b/safe_math.h
@@ -10,7 +10,7 @@
 
 // C wants a prototype, if all warnings enabled
 #if !defined SAFE_MATH_FAIL_DEFINED
-static inline void safe_math_fail(const char* msg);
+inline void safe_math_fail(const char* msg);
 #endif
 
 #include "safe_math_impl.h"

--- a/safe_math_impl.h
+++ b/safe_math_impl.h
@@ -125,7 +125,7 @@ extern "C"
 #include <stdlib.h>
 
 SAFEINT_NORETURN
-static inline void safe_math_fail(const char* msg)
+inline void safe_math_fail(const char* msg)
 {
     (void)msg;
     abort();

--- a/safe_math_impl.h
+++ b/safe_math_impl.h
@@ -57,6 +57,14 @@ extern "C"
 #define SAFEINT_WEAK
 #endif
 
+#if SAFEINT_COMPILER == VISUAL_STUDIO_COMPILER
+    // limits.h checks __STDC_WANT_SECURE_LIB__, but doesn't include what sets it
+#if !defined __STDC_WANT_SECURE_LIB__
+#define __STDC_WANT_SECURE_LIB__ 0
+#endif
+
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <limits.h>
@@ -116,7 +124,8 @@ extern "C"
 #define SAFE_MATH_FAIL_DEFINED
 #include <stdlib.h>
 
-SAFEINT_NORETURN void safe_math_fail(const char* msg)
+SAFEINT_NORETURN
+inline void safe_math_fail(const char* msg)
 {
     (void)msg;
     abort();

--- a/safe_math_impl.h
+++ b/safe_math_impl.h
@@ -125,7 +125,7 @@ extern "C"
 #include <stdlib.h>
 
 SAFEINT_NORETURN
-inline void safe_math_fail(const char* msg)
+static inline void safe_math_fail(const char* msg)
 {
     (void)msg;
     abort();


### PR DESCRIPTION
Fix problem where the library cannot be used if no C++ standard is specified. There is still a define needed, as things work better if C++11 or higher.

Remove the outdated inline help, please refer to helpfile.md
Rearrange the exception handler options, which were a mess. 
Add support for nodiscard attribute.
Add MSVC Cmake support
Add more warnings to clang options, fix resulting warnings, some users compile with -Wextra