### PR TITLE
Revert change that causes trouble with GCC 8.5.

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5491,12 +5491,6 @@ public:
         m_int = (T)SafeInt< T, E >( (U)u );
     }
 
-    _CONSTEXPR14 SafeInt(const SafeInt< T, E >& t) SAFEINT_CPP_THROW : m_int(0)
-    {
-        static_assert(safeint_internal::numeric_type< T >::isInt, "Integer type required");
-        m_int = t.m_int;
-    }
-
     template < typename U >
     _CONSTEXPR14 SafeInt( const U& i ) SAFEINT_CPP_THROW : m_int(0)
     {


### PR DESCRIPTION
This function was originally part of `6c4542323`, but caused compiler errors with GCC 8.5 processing some complex C++ code auto-generated by one of our tools. This started appearing after upgrading from an older `SafeInt` version, which was running fine, to current master. Through some bi-secting, I eventually found this function to be the culprit: removing it fixed the affected platforms without causing trouble anywhere else. However, I can't really assess if that's an appropriate change. 

Unfortunately, it's hard to track down what exactly is going on with GCC 8.5 here, or to reduce the issue down to some small excerpt that I could post here. So I figured I submit this as is for now. If the change is unclear/controversial, I can try to dig in a bit more and recover the compiler output or anything else that would be helpful. But I figured I'd start with what I got.