### PR TITLE
Fix regression because of adding copy constructor

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5491,12 +5491,8 @@ public:
         m_int = (T)SafeInt< T, E >( (U)u );
     }
 
-    _CONSTEXPR14 SafeInt(const SafeInt< T, E >& t) SAFEINT_CPP_THROW : m_int(0)
-    {
-        static_assert(safeint_internal::numeric_type< T >::isInt, "Integer type required");
-        m_int = t.m_int;
-    }
-
+    // Default constructor and move constructor cannot be declared,
+    // or gcc 8.x and 9.x breaks
     template < typename U >
     _CONSTEXPR14 SafeInt( const U& i ) SAFEINT_CPP_THROW : m_int(0)
     {
@@ -5505,12 +5501,6 @@ public:
         // SafeCast will throw exceptions if i won't fit in type T
         
         SafeCastHelper< T, U, GetCastMethod< T, U >::method >::template CastThrow< E >( i, m_int );
-    }
-
-    // Add a move constructor
-    _CONSTEXPR14 SafeInt(SafeInt<T>&& t) : m_int(t.m_int)
-    {
-        t.m_int = 0;
     }
 
     // The destructor is intentionally commented out - no destructor
@@ -5533,30 +5523,12 @@ public:
         return *this;
     }
 
-    _CONSTEXPR14 SafeInt< T, E >& operator =( const T& rhs ) SAFEINT_NOTHROW
-    {
-        m_int = rhs;
-        return *this;
-    }
-
-    // Move assignment
-    _CONSTEXPR14 SafeInt< T, E >& operator=( SafeInt<T>&& t)
-    {
-        m_int = t.m_int;
-        t.m_int = 0;
-        return *this;
-    }
-
+    // Note - move assignment and assignment operator from SafeInt<T> cannot be declared
+    // or it will break under some gcc versions.
     template < typename U >
     _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< U, E >& rhs ) SAFEINT_CPP_THROW
     {
         SafeCastHelper< T, U, GetCastMethod< T, U >::method >::template CastThrow< E >( rhs.Ref(), m_int );
-        return *this;
-    }
-
-    _CONSTEXPR14 SafeInt< T, E >& operator =( const SafeInt< T, E >& rhs ) SAFEINT_NOTHROW
-    {
-        m_int = rhs.m_int;
         return *this;
     }
 

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5507,11 +5507,16 @@ public:
         SafeCastHelper< T, U, GetCastMethod< T, U >::method >::template CastThrow< E >( i, m_int );
     }
 
+    // Add a move constructor
+    _CONSTEXPR14 SafeInt(SafeInt<T>&& t) : m_int(t.m_int)
+    {
+        t.m_int = 0;
+    }
+
     // The destructor is intentionally commented out - no destructor
     // vs. a do-nothing destructor makes a huge difference in
     // inlining characteristics. It wasn't doing anything anyway.
     // ~SafeInt(){};
-
 
     // now start overloading operators
     // assignment operator
@@ -5531,6 +5536,14 @@ public:
     _CONSTEXPR14 SafeInt< T, E >& operator =( const T& rhs ) SAFEINT_NOTHROW
     {
         m_int = rhs;
+        return *this;
+    }
+
+    // Move assignment
+    _CONSTEXPR14 SafeInt< T, E >& operator=( SafeInt<T>&& t)
+    {
+        m_int = t.m_int;
+        t.m_int = 0;
         return *this;
     }
 

--- a/Test/CompileTest.cpp
+++ b/Test/CompileTest.cpp
@@ -257,6 +257,32 @@ void CompileType()
 
 }
 
+void MoveRegression()
+{
+	#if CPLUSPLUS_STD == CPLUSPLUS_17
+	#include <variant>
+	#include <string>
+
+	template<typename... T>
+	class Union {
+	public:
+		Union() = default;
+		Union& operator=(Union&&) noexcept = default;
+
+		template<typename F>
+		Union& operator=(F&& t) {
+			value = std::forward<F>(t);
+			return *this;
+		}
+
+		std::variant<T...> value;
+	};
+
+	Union<std::string, SafeInt<int64_t>> x;
+	Union<std::string, SafeInt<int64_t>> y;
+	x = std::move(y);
+	#endif
+}
 void CompileMe()
 {
 	CompileType<char>();
@@ -277,7 +303,7 @@ void CompileMe()
 	CompileSigned<signed int>();
 	CompileSigned<signed long>();
 	CompileSigned<signed long long>();
-
+	MoveRegression();
 }
 
 /*

--- a/Test/GccTest/CMakeLists.txt
+++ b/Test/GccTest/CMakeLists.txt
@@ -105,6 +105,15 @@ else()
 
     target_compile_options(CompileTest_gcc PUBLIC -Wall)
 
+    add_executable(CompileTest_gcc17
+        ../CompileTest.cpp
+        ../ConstExpr.cpp 
+        ../CleanCompile.cpp
+        ../../SafeInt.hpp
+    )
+
+    target_compile_options(CompileTest_gcc17 PUBLIC -Wall -std=c++17)
+
     add_executable(CompileTest_gcc14
         ../CompileTest.cpp
         ../ConstExpr.cpp 


### PR DESCRIPTION
The change to add a copy constructor from SafeInt<T> to SafeInt<T> caused a regression in some versions of gcc. See MoveRegression() in CompileTest.cpp. It's not clear just why adding a copy constructor might cause this problem, particularly only in some compilers.

The problem came in when running clang with -Wall -Wextra, which caused warnings about a user-supplied assignment operator which didn't have a matching copy constructor. Adding a copy constructor seemed like the right approach, but it caused this regression.

In addition, adding a move constructor and move assignment operator was also tried, and it didn't help. In order to avoid the problem, it seems that none of:

copy constructor
move constructor
assignement operator
move assignment operator

can exist. It's fine that they don't exist, the defaults for all of these do the right thing. In addition, declaring these operators as = default also resulted in errors.

In addition, while clang was building with std=c++17, gcc was not. That's been corrected to ensure the regression test actually works (and general goodness, tests should be equivalent).