### PR TITLE
Change shift operators to throw on undefined behavior instead of assert [UPDATED]

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5380,7 +5380,7 @@ template < typename U, int signed > class bits_not_negative;
 template < typename U > class bits_not_negative < U, true >
 {
 public:
-    SAFE_INT_NODISCARD _CONSTEXPR14 static bool value(U bits)
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool value(U bits)
     {
         return bits >= 0;
     }
@@ -5389,14 +5389,14 @@ public:
 template < typename U > class bits_not_negative < U, false >
 {
 public:
-    SAFE_INT_NODISCARD _CONSTEXPR14 static bool value(U)
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool value(U)
     {
         return true;
     }
 };
 
 template < typename T, typename U > 
-SAFE_INT_NODISCARD _CONSTEXPR14 bool valid_bitcount(U bits)
+SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 bool valid_bitcount(U bits)
 {
     if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
     {
@@ -6025,7 +6025,7 @@ public:
     // Left shift
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6036,7 +6036,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6048,7 +6048,7 @@ public:
     // Left shift assignment
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits )
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6060,7 +6060,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits )
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6073,7 +6073,7 @@ public:
 
     // Right shift
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6084,7 +6084,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6096,7 +6096,7 @@ public:
 
     // Right shift assignment
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits )
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6108,7 +6108,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits )
     {
         if (valid_bitcount<T, U>(bits))
         {

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5374,10 +5374,31 @@ public:
     }
 };
 
+template < typename U, int signed > class bits_not_negative;
+
+// Signed case
+template < typename U > class bits_not_negative < U, true >
+{
+public:
+    SAFE_INT_NODISCARD _CONSTEXPR14 static bool value(U bits)
+    {
+        return bits >= 0;
+    }
+};
+
+template < typename U > class bits_not_negative < U, false >
+{
+public:
+    SAFE_INT_NODISCARD _CONSTEXPR14 static bool value(U)
+    {
+        return true;
+    }
+};
+
 template < typename T, typename U > 
 SAFE_INT_NODISCARD _CONSTEXPR14 bool valid_bitcount(U bits)
 {
-    if (!std::numeric_limits< U >::is_signed || bits >= 0)
+    if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
     {
         if (bits < (int)safeint_internal::int_traits< T >::bitCount)
         {
@@ -6945,20 +6966,24 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
 {
-    ShiftAssert( !std::numeric_limits< T >::is_signed || (T)bits >= 0 );
-    ShiftAssert( (T)bits < (int)safeint_internal::int_traits< U >::bitCount );
+    if (valid_bitcount<T, U>(bits))
+    {
+        return SafeInt< U, E >((U)(lhs << (T)bits));
+    }
 
-    return SafeInt< U, E >( (U)( lhs << (T)bits ) );
+    E::SafeIntOnOverflow();
 }
 
 // Right shift
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
 {
-    ShiftAssert( !std::numeric_limits< T >::is_signed || (T)bits >= 0 );
-    ShiftAssert( (T)bits < (int)safeint_internal::int_traits< U >::bitCount );
+    if (valid_bitcount<T, U>(bits))
+    {
+        return SafeInt< U, E >((U)(lhs >> (T)bits));
+    }
 
-    return SafeInt< U, E >( (U)( lhs >> (T)bits ) );
+    E::SafeIntOnOverflow();
 }
 
 // Bitwise operators

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5374,6 +5374,20 @@ public:
     }
 };
 
+template < typename T, typename U > 
+SAFE_INT_NODISCARD _CONSTEXPR14 bool valid_bitcount(U bits)
+{
+    if (!std::numeric_limits< U >::is_signed || bits >= 0)
+    {
+        if (bits < (int)safeint_internal::int_traits< T >::bitCount)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /*****************  External functions ****************************************/
 
 // External functions that can be used where you only need to check one operation
@@ -5988,25 +6002,26 @@ public:
     // code path is exactly the same as for SafeInt< U, E > as rhs
 
     // Left shift
-    // Also, shifting > bitcount is undefined - trap in debug
-    #define ShiftAssert(x) SAFEINT_ASSERT(x)
 
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || bits >= 0 );
-        ShiftAssert( bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            return SafeInt< T, E >((T)(m_int << bits));
+        }
 
-        return SafeInt< T, E >( (T)( m_int << bits ) );
+        E::SafeIntOnOverflow();
     }
 
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || (U)bits >= 0 );
-        ShiftAssert( (U)bits < (int)safeint_internal::int_traits< T >::bitCount );
-
-        return SafeInt< T, E >( (T)( m_int << (U)bits ) );
+        if (valid_bitcount<T, U>(bits))
+        {
+            return SafeInt< T, E >((T)(m_int << (U)bits));
+        }
+        E::SafeIntOnOverflow();
     }
 
     // Left shift assignment
@@ -6014,61 +6029,73 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || bits >= 0 );
-        ShiftAssert( bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            m_int <<= bits;
+            return *this;
+        }
 
-        m_int <<= bits;
-        return *this;
+        E::SafeIntOnOverflow();
     }
 
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || (U)bits >= 0 );
-        ShiftAssert( (U)bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            m_int <<= (U)bits;
+            return *this;
+        }
 
-        m_int <<= (U)bits;
-        return *this;
+        E::SafeIntOnOverflow();
     }
 
     // Right shift
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || bits >= 0 );
-        ShiftAssert( bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            return SafeInt< T, E >((T)(m_int >> bits));
+        }
 
-        return SafeInt< T, E >( (T)( m_int >> bits ) );
+        E::SafeIntOnOverflow();
     }
 
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || (U)bits >= 0 );
-        ShiftAssert( (U)bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            return SafeInt< T, E >((T)(m_int >> (U)bits));
+        }
 
-        return SafeInt< T, E >( (T)(m_int >> (U)bits) );
+        E::SafeIntOnOverflow();
     }
 
     // Right shift assignment
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || bits >= 0 );
-        ShiftAssert( bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            m_int >>= bits;
+            return *this;
+        }
 
-        m_int >>= bits;
-        return *this;
+        E::SafeIntOnOverflow();
     }
 
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
     {
-        ShiftAssert( !std::numeric_limits< U >::is_signed || (U)bits >= 0 );
-        ShiftAssert( (U)bits < (int)safeint_internal::int_traits< T >::bitCount );
+        if (valid_bitcount<T, U>(bits))
+        {
+            m_int >>= (U)bits;
+            return *this;
+        }
 
-        m_int >>= (U)bits;
-        return *this;
+        E::SafeIntOnOverflow();
     }
 
     // Bitwise operators

--- a/helpfile.md
+++ b/helpfile.md
@@ -324,7 +324,7 @@ The shift operators have the following signatures:
     SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits )
 
 Note:
-Shift operations where the right argument is larger than the number of bits in the left argument type minus 1 is implementation-defined behavior. SafeInt will attempt to help you avoid this by causing an assert in debug builds. If you prefer to have a stronger reaction, create a custom SAFEINT_ASSERT that throws or causes a fault in both debug and release builds. Shifting by a negative bit count also doesn't make sense, and is also trapped.
+Shift operations where the right argument is larger than the number of bits in the left argument type minus 1 is implementation-defined behavior. Undefined behavior, such as shifting by a negative count or more bits than the type has will throw an exception.
 
 ### Methods
 SafeInt has a a small number of methods that help with common problems, such as aligning a value, getting a pointer to the raw integer type, and helping to manage pointer arithmetic.


### PR DESCRIPTION
This is on top of https://github.com/dcleblanc/SafeInt/pull/64, fixing a couple of issues with the original version. This versions  seems to work as expected now.