### PR TITLE
Drop 'static' from SafeIntExceptionAssert for C++20 header unit support

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -420,9 +420,9 @@ enum SafeIntError
 // Now we need to define an exception handler
 // Internally defined exception handlers might assert
 #if defined SAFEINT_ASSERT_ON_EXCEPTION
-static inline void SafeIntExceptionAssert() SAFEINT_NOTHROW { SAFEINT_ASSERT(false); }
+inline void SafeIntExceptionAssert() SAFEINT_NOTHROW { SAFEINT_ASSERT(false); }
 #else
-static inline void SafeIntExceptionAssert() SAFEINT_NOTHROW {}
+inline void SafeIntExceptionAssert() SAFEINT_NOTHROW {}
 #endif
 
 #define SAFEINT_EXCEPTION_WIN32 0


### PR DESCRIPTION
Closes #61.  When SafeInt.hpp is consumed as a header unit (cl /exportHeader), the header is its own TU and 'static' gives SafeIntExceptionAssert internal linkage that's not visible to importers.  Per [basic.link]/2.3 use of an internal-linkage name from outside its TU is ill-formed; MSVC diagnoses this with C2129.

Plain 'inline' is ODR-multiply-defined-safe via standard mechanisms, deduplicates across TUs at link time, and works correctly with header units. Verified that multi-TU includes still link cleanly on gcc and clang.