### PR TITLE
Wrap numeric_limits<T>::max() / min() to prevent macro expansion

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -576,6 +576,30 @@ typedef safeint_exception_handlers::SafeInt_InvalidParameter InvalidParameterExc
 
 namespace safeint_internal
 {
+    // Wrappers around std::numeric_limits<T>::max() and ::min().  The
+    // parenthesizing ( (std::numeric_limits<T>::max)() ) suppresses
+    // function-like macro expansion, which matters when SafeInt.hpp is
+    // included after a header that defines `min` / `max` as macros --
+    // most notably <Windows.h> / <WinDef.h> when NOMINMAX is not also
+    // defined.  Centralizing the wrapper means call sites read naturally
+    // and future contributors can't accidentally reintroduce the bare
+    // numeric_limits<T>::max() form (issue #51).  Note that the macro
+    // defense lives only at the wrapper definition: a hypothetical
+    // member function of int_traits<T> named max() / min() would not
+    // help, since `int_traits<T>::max(` at the call site would still
+    // trip the function-like-macro expansion.
+    template < typename T >
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR11 inline T safeint_max() SAFEINT_NOTHROW
+    {
+        return (std::numeric_limits< T >::max)();
+    }
+
+    template < typename T >
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR11 inline T safeint_min() SAFEINT_NOTHROW
+    {
+        return (std::numeric_limits< T >::min)();
+    }
+
     // If we have support for std<typetraits>, then we can do this easily, and detect enums as well
     template < typename T > class numeric_type;
 
@@ -793,7 +817,7 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static T NegativeThrow( T t ) SAFEINT_CPP_THROW
     {
         // corner case
-        if( t != std::numeric_limits<T>::min() )
+        if( t != safeint_internal::safeint_min<T>() )
         {
             // cast prevents unneeded checks in the case of small ints
             return -t;
@@ -804,7 +828,7 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Negative(T t, T& out)
     {
         // corner case
-        if (t != std::numeric_limits<T>::min())
+        if (t != safeint_internal::safeint_min<T>())
         {
             out = -t;
             return true;
@@ -952,7 +976,7 @@ public:
             return false;
 
         // The input can now safely be cast to an unsigned long long
-        if (static_cast<std::uint64_t>(d) > std::numeric_limits<T>::max())
+        if (static_cast<std::uint64_t>(d) > safeint_internal::safeint_max<T>())
             return false;
 
         return true;
@@ -975,7 +999,7 @@ public:
 
         // And now cast to long long, and check against min and max for this type
         std::int64_t test = static_cast<std::int64_t>(d);
-        if ((std::int64_t)test < (std::int64_t)std::numeric_limits<T>::min() || (std::int64_t)test >(std::int64_t)std::numeric_limits<T>::max())
+        if ((std::int64_t)test < (std::int64_t)safeint_internal::safeint_min<T>() || (std::int64_t)test >(std::int64_t)safeint_internal::safeint_max<T>())
             return false;
 
         return true;
@@ -1112,7 +1136,7 @@ template < typename T, typename U > class SafeCastHelper < T, U, CastCheckGTMax 
 public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Cast( U u, T& t ) SAFEINT_NOTHROW
     {
-        if( u > (U)std::numeric_limits<T>::max() )
+        if( u > (U)safeint_internal::safeint_max<T>() )
             return false;
 
         t = (T)u;
@@ -1122,7 +1146,7 @@ public:
     template < typename E >
     SAFEINT_CONSTEXPR14 static void CastThrow( U u, T& t ) SAFEINT_CPP_THROW
     {
-        if( u > (U)std::numeric_limits<T>::max() )
+        if( u > (U)safeint_internal::safeint_max<T>() )
             E::SafeIntOnOverflow();
 
         t = (T)u;
@@ -1135,7 +1159,7 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Cast( U u, T& t ) SAFEINT_NOTHROW
     {
         // U is signed - T could be either signed or unsigned
-        if( u > std::numeric_limits<T>::max() || u < 0 )
+        if( u > safeint_internal::safeint_max<T>() || u < 0 )
             return false;
 
         t = (T)u;
@@ -1146,7 +1170,7 @@ public:
     SAFEINT_CONSTEXPR14 static void CastThrow( U u, T& t ) SAFEINT_CPP_THROW
     {
         // U is signed - T could be either signed or unsigned
-        if( u > std::numeric_limits<T>::max() || u < 0 )
+        if( u > safeint_internal::safeint_max<T>() || u < 0 )
             E::SafeIntOnOverflow();
 
         t = (T)u;
@@ -1159,7 +1183,7 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Cast( U u, T& t ) SAFEINT_NOTHROW
     {
         // T, U are signed
-        if( u > std::numeric_limits<T>::max() || u < std::numeric_limits<T>::min() )
+        if( u > safeint_internal::safeint_max<T>() || u < safeint_internal::safeint_min<T>() )
             return false;
 
         t = (T)u;
@@ -1170,7 +1194,7 @@ public:
     SAFEINT_CONSTEXPR14 static void CastThrow( U u, T& t ) SAFEINT_CPP_THROW
     {
         //T, U are signed
-        if( u > std::numeric_limits<T>::max() || u < std::numeric_limits<T>::min() )
+        if( u > safeint_internal::safeint_max<T>() || u < safeint_internal::safeint_min<T>() )
             E::SafeIntOnOverflow();
 
         t = (T)u;
@@ -1585,7 +1609,7 @@ public:
     {
         int tmp = t * u;
 
-        if( tmp > std::numeric_limits<T>::max() || tmp < std::numeric_limits<T>::min() )
+        if( tmp > safeint_internal::safeint_max<T>() || tmp < safeint_internal::safeint_min<T>() )
             return false;
 
         ret = (T)tmp;
@@ -1597,7 +1621,7 @@ public:
     {
         int tmp = t * u;
 
-        if( tmp > std::numeric_limits<T>::max() || tmp < std::numeric_limits<T>::min() )
+        if( tmp > safeint_internal::safeint_max<T>() || tmp < safeint_internal::safeint_min<T>() )
             E::SafeIntOnOverflow();
 
         ret = (T)tmp;
@@ -1612,7 +1636,7 @@ public:
     {
         unsigned int tmp = (unsigned int)t * (unsigned int)u;
 
-        if( tmp > std::numeric_limits<T>::max() )
+        if( tmp > safeint_internal::safeint_max<T>() )
             return false;
 
         ret = (T)tmp;
@@ -1624,7 +1648,7 @@ public:
     {
         unsigned int tmp = (unsigned int)( t * u );
 
-        if( tmp > std::numeric_limits<T>::max() )
+        if( tmp > safeint_internal::safeint_max<T>() )
             E::SafeIntOnOverflow();
 
         ret = (T)tmp;
@@ -1639,7 +1663,7 @@ public:
     {
         std::int64_t tmp = (std::int64_t)t * (std::int64_t)u;
 
-        if(tmp > (std::int64_t)std::numeric_limits<T>::max() || tmp < (std::int64_t)std::numeric_limits<T>::min())
+        if(tmp > (std::int64_t)safeint_internal::safeint_max<T>() || tmp < (std::int64_t)safeint_internal::safeint_min<T>())
             return false;
 
         ret = (T)tmp;
@@ -1651,7 +1675,7 @@ public:
     {
         std::int64_t tmp = (std::int64_t)t * (std::int64_t)u;
 
-        if(tmp > (std::int64_t)std::numeric_limits<T>::max() || tmp < (std::int64_t)std::numeric_limits<T>::min())
+        if(tmp > (std::int64_t)safeint_internal::safeint_max<T>() || tmp < (std::int64_t)safeint_internal::safeint_min<T>())
             E::SafeIntOnOverflow();
 
         ret = (T)tmp;
@@ -1666,7 +1690,7 @@ public:
     {
         std::uint64_t tmp = (std::uint64_t)t * (std::uint64_t)u;
 
-        if(tmp > (std::uint64_t)std::numeric_limits<T>::max())
+        if(tmp > (std::uint64_t)safeint_internal::safeint_max<T>())
             return false;
 
         ret = (T)tmp;
@@ -1678,7 +1702,7 @@ public:
     {
         std::uint64_t tmp = (std::uint64_t)t * (std::uint64_t)u;
 
-        if(tmp > (std::uint64_t)std::numeric_limits<T>::max())
+        if(tmp > (std::uint64_t)safeint_internal::safeint_max<T>())
             E::SafeIntOnOverflow();
 
         ret = (T)tmp;
@@ -1723,7 +1747,7 @@ SAFEINT_CONSTEXPR14 inline bool MultiplyInt64(std::int64_t a, std::int64_t b, st
     {
         if (tmp_high == 0)
         {
-            return (std::uint64_t)*pRet <= (std::uint64_t)std::numeric_limits<std::int64_t>::max();
+            return (std::uint64_t)*pRet <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>();
         }
     }
 
@@ -1767,7 +1791,7 @@ inline bool MultiplyInt64( std::int64_t a, std::int64_t b, std::int64_t* pRet ) 
     {
         // Result should be positive
         // Check for overflow
-        if( llHigh == 0 && (std::uint64_t)*pRet <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+        if( llHigh == 0 && (std::uint64_t)*pRet <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
             return true;
     }
     return false;
@@ -2098,7 +2122,7 @@ public:
 
         if( !fIsNegative )
         {
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int32_t >::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int32_t>() )
             {
                 *pRet = (std::int32_t)tmp;
                 return true;
@@ -2106,7 +2130,7 @@ public:
         }
         else
         {
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int32_t >::max()+1 )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int32_t>()+1 )
             {
                 *pRet = SignedNegation< std::int32_t >::Value( tmp );
                 return true;
@@ -2144,7 +2168,7 @@ public:
 
         if( !fIsNegative )
         {
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int32_t >::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int32_t>() )
             {
                 *pRet = (std::int32_t)tmp;
                 return;
@@ -2152,7 +2176,7 @@ public:
         }
         else
         {
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int32_t >::max()+1 )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int32_t>()+1 )
             {
                 *pRet = SignedNegation< std::int32_t >::Value( tmp );
                 return;
@@ -2255,7 +2279,7 @@ public:
             if( aNegative ^ bNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
                 {
                     *pRet = SignedNegation< std::int64_t >::Value( tmp );
                     return true;
@@ -2264,7 +2288,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
                 {
                     *pRet = (std::int64_t)tmp;
                     return true;
@@ -2308,7 +2332,7 @@ public:
         if( aNegative ^ bNegative )
         {
             // Result must be negative
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
             {
                 *pRet = SignedNegation< std::int64_t >::Value( tmp );
                 return;
@@ -2317,7 +2341,7 @@ public:
         else
         {
             // Result must be positive
-            if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
             {
                 *pRet = (std::int64_t)tmp;
                 return;
@@ -2353,7 +2377,7 @@ public:
             if( aNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
                 {
                     *pRet = SignedNegation< std::int64_t >::Value( tmp );
                     return true;
@@ -2362,7 +2386,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
                 {
                     *pRet = (std::int64_t)tmp;
                     return true;
@@ -2397,7 +2421,7 @@ public:
         if( aNegative )
         {
             // Result must be negative
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
             {
                 *pRet = SignedNegation< std::int64_t >::Value( tmp );
                 return;
@@ -2406,7 +2430,7 @@ public:
         else
         {
             // Result must be positive
-            if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
             {
                 *pRet = (std::int64_t)tmp;
                 return;
@@ -2451,7 +2475,7 @@ public:
             if( aNegative ^ bNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
                 {
                     *pRet = SignedNegation< std::int64_t >::Value( tmp );
                     return true;
@@ -2460,7 +2484,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
                 {
                     *pRet = (std::int64_t)tmp;
                     return true;
@@ -2502,7 +2526,7 @@ public:
         if( aNegative ^ bNegative )
         {
             // Result must be negative
-            if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
             {
                 *pRet = SignedNegation< std::int64_t >::Value( tmp );
                 return;
@@ -2511,7 +2535,7 @@ public:
         else
         {
             // Result must be positive
-            if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
             {
                 *pRet = (std::int64_t)tmp;
                 return;
@@ -2533,8 +2557,8 @@ public:
 
         if( MultiplyInt64( a, b, &tmp ) )
         {
-            if( tmp > std::numeric_limits< std::int32_t >::max() ||
-                tmp < std::numeric_limits< std::int32_t >::min() )
+            if( tmp > safeint_internal::safeint_max<std::int32_t>() ||
+                tmp < safeint_internal::safeint_min<std::int32_t>() )
             {
                 return false;
             }
@@ -2568,7 +2592,7 @@ public:
             if( aNegative ^ bNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint32_t)std::numeric_limits< std::int32_t >::min() )
+                if( tmp <= (std::uint32_t)safeint_internal::safeint_min<std::int32_t>() )
                 {
                     *pRet = SignedNegation< std::int32_t >::Value( tmp );
                     return true;
@@ -2577,7 +2601,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint32_t)std::numeric_limits< std::int32_t >::max() )
+                if( tmp <= (std::uint32_t)safeint_internal::safeint_max<std::int32_t>() )
                 {
                     *pRet = (std::int32_t)tmp;
                     return true;
@@ -2597,8 +2621,8 @@ public:
 
         if( MultiplyInt64( a, b, &tmp ) )
         {
-            if( tmp > std::numeric_limits< std::int32_t >::max() ||
-                tmp < std::numeric_limits< std::int32_t >::min() )
+            if( tmp > safeint_internal::safeint_max<std::int32_t>() ||
+                tmp < safeint_internal::safeint_min<std::int32_t>() )
             {
                 E::SafeIntOnOverflow();
             }
@@ -2632,7 +2656,7 @@ public:
         if( aNegative ^ bNegative )
         {
             // Result must be negative
-            if( tmp <= (std::uint32_t)std::numeric_limits< std::int32_t >::min() )
+            if( tmp <= (std::uint32_t)safeint_internal::safeint_min<std::int32_t>() )
             {
                 *pRet = SignedNegation< std::int32_t >::Value( tmp );
                 return;
@@ -2641,7 +2665,7 @@ public:
         else
         {
             // Result must be positive
-            if( tmp <= (std::uint32_t)std::numeric_limits< std::int32_t >::max() )
+            if( tmp <= (std::uint32_t)safeint_internal::safeint_max<std::int32_t>() )
             {
                 *pRet = (std::int32_t)tmp;
                 return;
@@ -2676,7 +2700,7 @@ public:
             if( aNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
                 {
                     *pRet = SignedNegation< std::int64_t >::Value( tmp );
                     return true;
@@ -2685,7 +2709,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
                 {
                     *pRet = (std::int64_t)tmp;
                     return true;
@@ -2715,7 +2739,7 @@ public:
             if( aNegative )
             {
                 // Result must be negative
-                if( tmp <= (std::uint64_t)std::numeric_limits< std::int64_t >::min() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_min<std::int64_t>() )
                 {
                     *pRet = SignedNegation< std::int64_t >::Value( tmp );
                     return;
@@ -2724,7 +2748,7 @@ public:
             else
             {
                 // Result must be positive
-                if( tmp <= (std::uint64_t)std::numeric_limits<std::int64_t>::max() )
+                if( tmp <= (std::uint64_t)safeint_internal::safeint_max<std::int64_t>() )
                 {
                     *pRet = (std::int64_t)tmp;
                     return;
@@ -3291,12 +3315,12 @@ public:
             return SafeIntNoError;
         }
 
-        if( u <= (std::uint64_t)std::numeric_limits<T>::max() )
+        if( u <= (std::uint64_t)safeint_internal::safeint_max<T>() )
         {
             result = div_signed_uint64 < T, U, sizeof(T) < sizeof(std::int64_t) > ::divide(t, u);
         }
         else // Corner case
-        if( t == std::numeric_limits<T>::min() && u == (std::uint64_t)std::numeric_limits<T>::min() )
+        if( t == safeint_internal::safeint_min<T>() && u == (std::uint64_t)safeint_internal::safeint_min<T>() )
         {
             // Min int divided by it's own magnitude is -1
             result = -1;
@@ -3324,12 +3348,12 @@ public:
             return;
         }
 
-        if( u <= (std::uint64_t)std::numeric_limits<T>::max() )
+        if( u <= (std::uint64_t)safeint_internal::safeint_max<T>() )
         {
             result = div_signed_uint64 < T, U, sizeof(T) < sizeof(std::int64_t) > ::divide(t, u);
         }
         else // Corner case
-        if( t == std::numeric_limits<T>::min() && u == (std::uint64_t)std::numeric_limits<T>::min() )
+        if( t == safeint_internal::safeint_min<T>() && u == (std::uint64_t)safeint_internal::safeint_min<T>() )
         {
             // Min int divided by it's own magnitude is -1
             result = -1;
@@ -3398,7 +3422,7 @@ public:
         }
 
         // Must test for corner case
-        if( t == std::numeric_limits<T>::min() && u == (U)-1 )
+        if( t == safeint_internal::safeint_min<T>() && u == (U)-1 )
             return SafeIntArithmeticOverflow;
 
         result = (T)( t/u );
@@ -3420,7 +3444,7 @@ public:
         }
 
         // Must test for corner case
-        if( t == std::numeric_limits<T>::min() && u == (U)-1 )
+        if( t == safeint_internal::safeint_min<T>() && u == (U)-1 )
             E::SafeIntOnOverflow();
 
         result = (T)( t/u );
@@ -3494,7 +3518,7 @@ public:
         //16-bit or less unsigned addition
         std::int32_t tmp = lhs + rhs;
 
-        if( tmp <= (std::int32_t)std::numeric_limits<T>::max() )
+        if( tmp <= (std::int32_t)safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3509,7 +3533,7 @@ public:
         //16-bit or less unsigned addition
         std::int32_t tmp = lhs + rhs;
 
-        if( tmp <= (std::int32_t)std::numeric_limits<T>::max() )
+        if( tmp <= (std::int32_t)safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return;
@@ -3561,7 +3585,7 @@ public:
         std::uint32_t tmp = (std::uint32_t)lhs + (std::uint32_t)rhs;
 
         // We added and it didn't get smaller or exceed maxInt
-        if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+        if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3576,7 +3600,7 @@ public:
         std::uint32_t tmp = (std::uint32_t)lhs + (std::uint32_t)rhs;
 
         // We added and it didn't get smaller or exceed maxInt
-        if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+        if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return;
@@ -3629,7 +3653,7 @@ public:
         std::uint64_t tmp = (std::uint64_t)lhs + (std::uint64_t)rhs;
 
         // We added and it didn't get smaller
-        if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+        if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3645,7 +3669,7 @@ public:
         std::uint64_t tmp = (std::uint64_t)lhs + (std::uint64_t)rhs;
 
         // We added and it didn't get smaller
-        if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+        if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return;
@@ -3663,7 +3687,7 @@ public:
         // 16-bit or less - one or both are signed
         std::int32_t tmp = lhs + rhs;
 
-        if( tmp <= (std::int32_t)std::numeric_limits<T>::max() && tmp >= (std::int32_t)std::numeric_limits<T>::min() )
+        if( tmp <= (std::int32_t)safeint_internal::safeint_max<T>() && tmp >= (std::int32_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3678,7 +3702,7 @@ public:
         // 16-bit or less - one or both are signed
         std::int32_t tmp = lhs + rhs;
 
-        if( tmp <= (std::int32_t)std::numeric_limits<T>::max() && tmp >= (std::int32_t)std::numeric_limits<T>::min() )
+        if( tmp <= (std::int32_t)safeint_internal::safeint_max<T>() && tmp >= (std::int32_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return;
@@ -3696,7 +3720,7 @@ public:
         // 32-bit or less - one or both are signed
         std::int64_t tmp = (std::int64_t)lhs + (std::int64_t)rhs;
 
-        if( tmp <= (std::int64_t)std::numeric_limits<T>::max() && tmp >= (std::int64_t)std::numeric_limits<T>::min() )
+        if( tmp <= (std::int64_t)safeint_internal::safeint_max<T>() && tmp >= (std::int64_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3711,7 +3735,7 @@ public:
         // 32-bit or less - one or both are signed
         std::int64_t tmp = (std::int64_t)lhs + (std::int64_t)rhs;
 
-        if( tmp <= (std::int64_t)std::numeric_limits<T>::max() && tmp >= (std::int64_t)std::numeric_limits<T>::min() )
+        if( tmp <= (std::int64_t)safeint_internal::safeint_max<T>() && tmp >= (std::int64_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return;
@@ -3729,7 +3753,7 @@ public:
         // 32-bit or less - lhs signed, rhs unsigned
         std::int64_t tmp = (std::int64_t)lhs + (std::int64_t)rhs;
 
-        if( tmp <= std::numeric_limits<T>::max() )
+        if( tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3744,7 +3768,7 @@ public:
         // 32-bit or less - lhs signed, rhs unsigned
         std::int64_t tmp = (std::int64_t)lhs + (std::int64_t)rhs;
 
-        if( tmp <= std::numeric_limits<T>::max() )
+        if( tmp <= safeint_internal::safeint_max<T>() )
         {
             result = (T)tmp;
             return;
@@ -3844,7 +3868,7 @@ public:
 
             // special case - rhs cannot be larger than 0x7fffffffffffffff, lhs cannot be larger than 0xffffffff
             // it is not possible for the operation above to overflow, so just check max
-            if( tmp <= std::numeric_limits<T>::max() )
+            if( tmp <= safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return true;
@@ -3872,7 +3896,7 @@ public:
 
             // special case - rhs cannot be larger than 0x7fffffffffffffff, lhs cannot be larger than 0xffffffff
             // it is not possible for the operation above to overflow, so just check max
-            if( tmp <= std::numeric_limits<T>::max() )
+            if( tmp <= safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return;
@@ -3939,8 +3963,8 @@ public:
         std::int64_t tmp = 0;
 
         if( AdditionHelper< std::int64_t, std::int64_t, AdditionState_CastInt64CheckOverflow >::Addition( (std::int64_t)lhs, (std::int64_t)rhs, tmp ) &&
-            tmp <= std::numeric_limits<T>::max() &&
-            tmp >= std::numeric_limits<T>::min() )
+            tmp <= safeint_internal::safeint_max<T>() &&
+            tmp >= safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return true;
@@ -3957,8 +3981,8 @@ public:
 
         AdditionHelper< std::int64_t, std::int64_t, AdditionState_CastInt64CheckOverflow >::AdditionThrow< E >( (std::int64_t)lhs, (std::int64_t)rhs, tmp );
 
-        if( tmp <= std::numeric_limits<T>::max() &&
-            tmp >= std::numeric_limits<T>::min() )
+        if( tmp <= safeint_internal::safeint_max<T>() &&
+            tmp >= safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return;
@@ -4306,7 +4330,7 @@ public:
         // rhs is unsigned - check only minimum
         std::int32_t tmp = lhs - rhs;
 
-        if( tmp >= (std::int32_t)std::numeric_limits<T>::min() )
+        if( tmp >= (std::int32_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return true;
@@ -4322,7 +4346,7 @@ public:
         // rhs is unsigned - check only minimum
         std::int32_t tmp = lhs - rhs;
 
-        if( tmp >= (std::int32_t)std::numeric_limits<T>::min() )
+        if( tmp >= (std::int32_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return;
@@ -4387,7 +4411,7 @@ public:
         // rhs is unsigned - check only minimum
         std::int64_t tmp = (std::int64_t)lhs - (std::int64_t)rhs;
 
-        if( tmp >= (std::int64_t)std::numeric_limits<T>::min() )
+        if( tmp >= (std::int64_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return true;
@@ -4403,7 +4427,7 @@ public:
         // rhs is unsigned - check only minimum
         std::int64_t tmp = (std::int64_t)lhs - (std::int64_t)rhs;
 
-        if( tmp >= (std::int64_t)std::numeric_limits<T>::min() )
+        if( tmp >= (std::int64_t)safeint_internal::safeint_min<T>() )
         {
             result = (T)tmp;
             return;
@@ -4482,7 +4506,7 @@ public:
             tmp = lhs + (std::uint64_t)AbsValueHelper< T, GetAbsMethod< T >::method >::Abs( rhs );
 
             // must check for addition overflow and max
-            if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+            if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return true;
@@ -4501,7 +4525,7 @@ public:
             // result is positive
             std::uint64_t tmp = (std::uint64_t)lhs - (std::uint64_t)rhs;
 
-            if( tmp <= std::numeric_limits<T>::max() )
+            if( tmp <= safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return true;
@@ -4523,7 +4547,7 @@ public:
             tmp = lhs + (std::uint64_t)AbsValueHelper< T, GetAbsMethod< T >::method >::Abs( rhs );
 
             // must check for addition overflow and max
-            if( tmp >= lhs && tmp <= (std::uint64_t)std::numeric_limits<T>::max() )
+            if( tmp >= lhs && tmp <= (std::uint64_t)safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return;
@@ -4542,7 +4566,7 @@ public:
             // result is positive
             std::uint64_t tmp = (std::uint64_t)lhs - (std::uint64_t)rhs;
 
-            if( tmp <= (std::uint64_t)std::numeric_limits<T>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return;
@@ -4576,7 +4600,7 @@ public:
             std::uint64_t tmp = lhs + ~(std::uint64_t)( rhs ) + 1; // negation safe
 
             // but we could exceed MaxInt
-            if(tmp <= std::numeric_limits<T>::max())
+            if(tmp <= safeint_internal::safeint_max<T>())
             {
                 result = (T)tmp;
                 return true;
@@ -4607,7 +4631,7 @@ public:
             std::uint64_t tmp = lhs + ~(std::uint64_t)( rhs ) + 1; // negation safe
 
             // but we could exceed MaxInt
-            if(tmp <= std::numeric_limits<T>::max())
+            if(tmp <= safeint_internal::safeint_max<T>())
             {
                 result = (T)tmp;
                 return;
@@ -4636,7 +4660,7 @@ public:
             // which cannot overflow internally
             std::uint64_t tmp = (std::uint64_t)lhs + (std::uint64_t)( -rhs );
 
-            if( tmp <= (std::uint64_t)std::numeric_limits<T>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return true;
@@ -4662,7 +4686,7 @@ public:
             // which cannot overflow internally
             std::uint64_t tmp = (std::uint64_t)lhs + (std::uint64_t)( -rhs );
 
-            if( tmp <= (std::uint64_t)std::numeric_limits<T>::max() )
+            if( tmp <= (std::uint64_t)safeint_internal::safeint_max<T>() )
             {
                 result = (T)tmp;
                 return;
@@ -4734,12 +4758,12 @@ template < typename T, typename U> class subtract_corner_case_max < T, U, true>
 public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool isOverflowPositive(const T& rhs, const U& lhs, std::int64_t tmp)
     {
-        return (tmp > std::numeric_limits<T>::max() || (rhs < 0 && tmp < lhs));
+        return (tmp > safeint_internal::safeint_max<T>() || (rhs < 0 && tmp < lhs));
     }
 
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool isOverflowNegative(const T& rhs, const U& lhs, std::int64_t tmp)
     {
-         return (tmp < std::numeric_limits<T>::min() || (rhs >= 0 && tmp > lhs));
+         return (tmp < safeint_internal::safeint_min<T>() || (rhs >= 0 && tmp > lhs));
     }
 };
 
@@ -4849,7 +4873,7 @@ public:
             // first case
             if( rhs >= 0 )
             {
-                if( tmp >= std::numeric_limits<T>::min() )
+                if( tmp >= safeint_internal::safeint_min<T>() )
                 {
                     result = (T)tmp;
                     return true;
@@ -4858,7 +4882,7 @@ public:
             else
             {
                 // second case
-                if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+                if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
                 {
                     result = (T)tmp;
                     return true;
@@ -4871,7 +4895,7 @@ public:
             // third case
             if( rhs >= 0 )
             {
-                if( tmp <= lhs && tmp >= std::numeric_limits<T>::min() )
+                if( tmp <= lhs && tmp >= safeint_internal::safeint_min<T>() )
                 {
                     result = (T)tmp;
                     return true;
@@ -4880,7 +4904,7 @@ public:
             else
             {
                 // fourth case
-                if( tmp <= std::numeric_limits<T>::max() )
+                if( tmp <= safeint_internal::safeint_max<T>() )
                 {
                     result = (T)tmp;
                     return true;
@@ -4909,7 +4933,7 @@ public:
             // first case
             if( rhs >= 0 )
             {
-                if( tmp >= std::numeric_limits<T>::min() )
+                if( tmp >= safeint_internal::safeint_min<T>() )
                 {
                     result = (T)tmp;
                     return;
@@ -4918,7 +4942,7 @@ public:
             else
             {
                 // second case
-                if( tmp >= lhs && tmp <= std::numeric_limits<T>::max() )
+                if( tmp >= lhs && tmp <= safeint_internal::safeint_max<T>() )
                 {
                     result = (T)tmp;
                     return;
@@ -4931,7 +4955,7 @@ public:
             // third case
             if( rhs >= 0 )
             {
-                if( tmp <= lhs && tmp >= std::numeric_limits<T>::min() )
+                if( tmp <= lhs && tmp >= safeint_internal::safeint_min<T>() )
                 {
                     result = (T)tmp;
                     return;
@@ -4940,7 +4964,7 @@ public:
             else
             {
                 // fourth case
-                if( tmp <= std::numeric_limits<T>::max() )
+                if( tmp <= safeint_internal::safeint_max<T>() )
                 {
                     result = (T)tmp;
                     return;
@@ -5032,7 +5056,7 @@ public:
         // Do this as unsigned to prevent unwanted optimizations
         std::uint64_t tmp = (std::uint64_t)lhs - (std::uint64_t)rhs;
 
-        if( (std::int64_t)tmp <= std::numeric_limits<T>::max() && (std::int64_t)tmp >= std::numeric_limits<T>::min() )
+        if( (std::int64_t)tmp <= safeint_internal::safeint_max<T>() && (std::int64_t)tmp >= safeint_internal::safeint_min<T>() )
         {
             result = (T)(std::int64_t)tmp;
             return true;
@@ -5047,7 +5071,7 @@ public:
         // Do this as unsigned to prevent unwanted optimizations
         std::uint64_t tmp = (std::uint64_t)lhs - (std::uint64_t)rhs;
 
-        if( (std::int64_t)tmp <= std::numeric_limits<T>::max() && (std::int64_t)tmp >= std::numeric_limits<T>::min() )
+        if( (std::int64_t)tmp <= safeint_internal::safeint_max<T>() && (std::int64_t)tmp >= safeint_internal::safeint_min<T>() )
         {
             result = (T)(std::int64_t)tmp;
             return;
@@ -5067,7 +5091,7 @@ public:
 
         // We need the absolute value of std::numeric_limits<T>::min()
         // This will give it to us without extraneous compiler warnings
-        const std::uint64_t AbsMinIntT = (std::uint64_t)std::numeric_limits<T>::max() + 1;
+        const std::uint64_t AbsMinIntT = (std::uint64_t)safeint_internal::safeint_max<T>() + 1;
 
         if( lhs < 0 )
         {
@@ -5097,7 +5121,7 @@ public:
 
         // We need the absolute value of std::numeric_limits<T>::min()
         // This will give it to us without extraneous compiler warnings
-        SAFEINT_CONSTEXPR11 std::uint64_t AbsMinIntT = (std::uint64_t)std::numeric_limits<T>::max() + 1;
+        SAFEINT_CONSTEXPR11 std::uint64_t AbsMinIntT = (std::uint64_t)safeint_internal::safeint_max<T>() + 1;
 
         if( lhs < 0 )
         {
@@ -5743,7 +5767,7 @@ public:
     // prefix increment operator
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator ++() SAFEINT_CPP_THROW
     {
-        if( m_int != std::numeric_limits<T>::max() )
+        if( m_int != safeint_internal::safeint_max<T>() )
         {
             ++m_int;
             return *this;
@@ -5754,7 +5778,7 @@ public:
     // prefix decrement operator
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator --() SAFEINT_CPP_THROW
     {
-        if( m_int != std::numeric_limits<T>::min() )
+        if( m_int != safeint_internal::safeint_min<T>() )
         {
             --m_int;
             return *this;
@@ -5768,7 +5792,7 @@ public:
     // postfix increment operator
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator ++( int )  SAFEINT_CPP_THROW // dummy arg to comply with spec
     {
-        if( m_int != std::numeric_limits<T>::max() )
+        if( m_int != safeint_internal::safeint_max<T>() )
         {
             SafeInt< T, E > tmp( m_int );
 
@@ -5781,7 +5805,7 @@ public:
     // postfix decrement operator
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator --( int ) SAFEINT_CPP_THROW // dummy arg to comply with spec
     {
-        if( m_int != std::numeric_limits<T>::min() )
+        if( m_int != safeint_internal::safeint_min<T>() )
         {
             SafeInt< T, E > tmp( m_int );
             m_int--;
@@ -6239,13 +6263,13 @@ public:
     }
 
     // Miscellaneous helper functions
-    SafeInt< T, E > Min( SafeInt< T, E > test, const T floor = std::numeric_limits<T>::min() ) const SAFEINT_NOTHROW
+    SafeInt< T, E > Min( SafeInt< T, E > test, const T floor = safeint_internal::safeint_min<T>() ) const SAFEINT_NOTHROW
     {
         T tmp = test < m_int ? (T)test : m_int;
         return tmp < floor ? floor : tmp;
     }
 
-    SafeInt< T, E > Max( SafeInt< T, E > test, const T upper = std::numeric_limits<T>::max() ) const SAFEINT_NOTHROW
+    SafeInt< T, E > Max( SafeInt< T, E > test, const T upper = safeint_internal::safeint_max<T>() ) const SAFEINT_NOTHROW
     {
         T tmp = test > m_int ? (T)test : m_int;
         return tmp > upper ? upper : tmp;
@@ -6626,17 +6650,17 @@ public:
         // any operator casts now do the right thing
         U tmp = division_negative_negateU< T, U, sizeof(T) == 4>::div(rhs, lhs);
 
-        if( tmp <= (U)std::numeric_limits<T>::max() )
+        if( tmp <= (U)safeint_internal::safeint_max<T>() )
         {
             result = SafeInt< T, E >( (T)(~(std::uint64_t)tmp + 1) );
             return true;
         }
 
         // Corner case
-        T maxT = std::numeric_limits<T>::max();
+        T maxT = safeint_internal::safeint_max<T>();
         if( tmp == (U)maxT + 1 )
         {
-            T minT = std::numeric_limits<T>::min();
+            T minT = safeint_internal::safeint_min<T>();
             result = SafeInt< T, E >( minT );
             return true;
         }
@@ -6699,7 +6723,7 @@ template < typename T, typename U > class div_negate_min < T, U , true >
 public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Value(T& ret)
     {
-        ret = (T)(-(T)std::numeric_limits< U >::min());
+        ret = (T)(-(T)safeint_internal::safeint_min<U>());
         return true;
     }
 };
@@ -6718,7 +6742,7 @@ template < typename T, typename U, typename E > class DivisionCornerCaseHelper2 
 public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool DivisionCornerCase2( U lhs, SafeInt< T, E > rhs, SafeInt<T, E>& result ) SAFEINT_CPP_THROW
     {
-        if( lhs == std::numeric_limits< U >::min() && (T)rhs == -1 )
+        if( lhs == safeint_internal::safeint_min<U>() && (T)rhs == -1 )
         {
             // corner case of a corner case - lhs = min int, rhs = -1,
             // but rhs is the return type, so in essence, we can return -lhs


### PR DESCRIPTION
Closes #51.  When SafeInt.hpp is included after a header that defines 'min' and 'max' as function-like macros (notably <Windows.h> / <WinDef.h> without NOMINMAX), the bare numeric_limits<T>::max() form is rewritten by the preprocessor as max() with no args, producing syntax errors.

Add safeint_internal::safeint_max<T>() / safeint_min<T>() wrappers that use the parenthesized (std::numeric_limits<T>::max)() idiom to suppress macro expansion, and update all 124 call sites.  Centralizing the workaround in the wrapper definitions means future contributors can't accidentally reintroduce the bare form.