### PR TITLE
Eliminate signed-overflow UB in non-member subtraction helpers

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -4763,7 +4763,10 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Subtract( const U& lhs, const T& rhs, T& result ) SAFEINT_NOTHROW
     {
         // lhs std::int64_t, rhs any signed int (including std::int64_t)
-        std::int64_t tmp = lhs - rhs;
+        // Perform the subtraction in unsigned to avoid signed-overflow UB
+        // for inputs near the int64 boundaries (e.g. INT64_MAX - (-1)).
+        // The post-check below then validates the wrapped result.
+        std::int64_t tmp = (std::int64_t)((std::uint64_t)lhs - (std::uint64_t)rhs);
 
         // we have essentially 4 cases:
         //
@@ -4798,7 +4801,10 @@ public:
     SAFEINT_CONSTEXPR14 static void SubtractThrow( const U& lhs, const T& rhs, T& result ) SAFEINT_CPP_THROW
     {
         // lhs std::int64_t, rhs any signed int (including std::int64_t)
-        std::int64_t tmp = lhs - rhs;
+        // Perform the subtraction in unsigned to avoid signed-overflow UB
+        // for inputs near the int64 boundaries (e.g. INT64_MAX - (-1)).
+        // The post-check below then validates the wrapped result.
+        std::int64_t tmp = (std::int64_t)((std::uint64_t)lhs - (std::uint64_t)rhs);
 
         // we have essentially 4 cases:
         //
@@ -4958,7 +4964,10 @@ public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Subtract( const U& lhs, const T& rhs, T& result ) SAFEINT_NOTHROW
     {
         // lhs is any signed int32 or smaller, rhs is int64
-        std::int64_t tmp = (std::int64_t)lhs - rhs;
+        // Perform the subtraction in unsigned to avoid signed-overflow UB
+        // for inputs near the int64 boundaries (e.g. 1 - INT64_MIN).  The
+        // post-check below then validates the wrapped result.
+        std::int64_t tmp = (std::int64_t)((std::uint64_t)lhs - (std::uint64_t)rhs);
 
         if( ( lhs >= 0 && rhs < 0 && tmp < lhs ) ||
             ( rhs > 0 && tmp > lhs ) )
@@ -4975,7 +4984,10 @@ public:
     SAFEINT_CONSTEXPR14 static void SubtractThrow( const U& lhs, const T& rhs, T& result ) SAFEINT_CPP_THROW
     {
         // lhs is any signed int32 or smaller, rhs is int64
-        std::int64_t tmp = (std::int64_t)lhs - rhs;
+        // Perform the subtraction in unsigned to avoid signed-overflow UB
+        // for inputs near the int64 boundaries (e.g. 1 - INT64_MIN).  The
+        // post-check below then validates the wrapped result.
+        std::int64_t tmp = (std::int64_t)((std::uint64_t)lhs - (std::uint64_t)rhs);
 
         if( ( lhs >= 0 && rhs < 0 && tmp < lhs ) ||
             ( rhs > 0 && tmp > lhs ) )


### PR DESCRIPTION
Closes #76.  Two SubtractionHelper specializations in the U-lhs / SafeInt<T>-rhs (free-function) family computed tmp = lhs - rhs as plain signed subtraction, which is undefined behavior for inputs near the int64 boundaries (e.g. INT64_MAX - (-1) or INT64_MIN - 1).  Under clang -O2 / -O3 the optimizer was already exploiting this UB to elide the post-check, returning silently-wrong results without throwing SafeIntException.  Reproducer (from Logan Gabriel, issue #76):

    std::int64_t lhs = INT64_MAX;
    SafeInt<std::int64_t> rhs(-1);
    auto result = lhs - rhs;  // returned INT64_MIN under clang -O2

Apply the same (int64_t)((uint64_t)lhs - (uint64_t)rhs) pattern that the matching member-form siblings (SubtractionState_Int64Int and IntInt64) already use.  Affected helpers:

  - SubtractionState_Int64Int2
  - SubtractionState_IntInt642

Audited the rest of the SubtractionHelper, AdditionHelper, and MultiplicationHelper families; no other UB sites of this class exist. Verified that all three PoC cases from issue #76 now throw correctly under clang -O2/-O3 and clang+UBSan, and that existing SubVerify (thousands of subtraction cases) is clean under UBSan.