### PR TITLE
Cast enum sources through underlying_type, not int

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -1038,16 +1038,23 @@ public:
 
 template < typename T, typename U > class SafeCastHelper < T, U, CastFromEnum >
 {
+    // Route through the enum's actual underlying type rather than always
+    // through int.  Wide enums (underlying_type wider than int, or values
+    // that don't fit in int) were previously truncated by static_cast<int>
+    // before the range check ran -- a SafeInt<uint64_t> built from an
+    // enum class : uint64_t value of 0x100000001 would silently store 1.
+    // (Issue #77.)
+    typedef typename std::underlying_type< U >::type underlying;
 public:
     SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool Cast(U u, T& t) SAFEINT_NOTHROW
     {
-        return SafeCastHelper< T, int, GetCastMethod< T, int >::method >::Cast(static_cast<int>(u), t);
+        return SafeCastHelper< T, underlying, GetCastMethod< T, underlying >::method >::Cast(static_cast<underlying>(u), t);
     }
 
     template < typename E >
     SAFEINT_CONSTEXPR14 static void CastThrow(U u, T& t) SAFEINT_CPP_THROW
     {
-        SafeCastHelper< T, int, GetCastMethod< T, int >::method >::template CastThrow< E >(static_cast<int>(u), t);
+        SafeCastHelper< T, underlying, GetCastMethod< T, underlying >::method >::template CastThrow< E >(static_cast<underlying>(u), t);
     }
 };
 


### PR DESCRIPTION
Closes #77.  CastFromEnum::Cast did static_cast<int>(u) before delegating to the underlying SafeCastHelper that does the range check. For any enum whose underlying type or value did not fit in int, this silently truncated the value before validation:

  enum class WideEnum : std::uint64_t { Big = 4294967297ULL };
  SafeInt<std::uint64_t> x = WideEnum::Big;  // stored 1, not 4294967297
  SafeInt<std::uint8_t>  y = WideEnum::Big;  // stored 1, did not throw

Route through std::underlying_type<U>::type instead.  This is lossless, matches the enum's declared representation, and lets the existing SafeCastHelper specialization for that underlying type do the proper range check.  Backward-compatible for enums that already had int (or narrower) as their underlying type.