### PR TITLE
Fix UB in align, and an actual bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 /Test/MsvcTest/CMakeSettings.json
 /.vs
 Test/c_safe_math/c_safe_math.vcxproj
+/Test/SafeIntTestVS17/Scratch/Scratch.exe
+/Test/SafeIntTestVS17/Scratch/Scratch.obj

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5395,19 +5395,102 @@ public:
     }
 };
 
-template < typename T, typename U > 
-SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 bool valid_bitcount(U bits)
-{
-    if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
-    {
-        if (bits < (int)safeint_internal::int_traits< T >::bitCount)
-        {
-            return true;
-        }
-    }
+// Shift validation uses the enum-dispatch pattern used elsewhere in this file
+// (see BinaryMethod / BinaryAndHelper, AdditionMethod / AdditionHelper, etc.):
+// a compile-time enum value is computed from properties of T, and a helper
+// class template is specialized on that enum to perform the validation.
+//
+// Three states cover the shift rules:
+//
+//   ShiftState_RightShift
+//       Any T.  The lhs value does not affect well-definedness of >> on any
+//       supported platform; only the bit count needs to be in [0, bitCount<T>).
+//
+//   ShiftState_LeftShiftUnsigned
+//       Unsigned T.  Wraparound is well-defined; only the bit count matters,
+//       same range as right shift.
+//
+//   ShiftState_LeftShiftSigned
+//       Signed T.  Bit count must be in [0, bitCount<T> - 1), AND the lhs
+//       value must not have any bits set that would shift into or past the
+//       sign bit.  Shifting a negative signed value, or shifting a positive
+//       value into the sign bit, is undefined behavior pre-C++20.
+//
+// The signed-left-shift value check uses an unsigned-cast trick to fold both
+// failure modes (negative lhs, and positive lhs that would overflow into the
+// sign bit) into one comparison: a negative lhs casts to a large unsigned
+// value that exceeds the threshold, and a too-large positive lhs fails
+// directly.
 
-    return false;
-}
+enum ShiftState
+{
+    ShiftState_RightShift,
+    ShiftState_LeftShiftUnsigned,
+    ShiftState_LeftShiftSigned
+};
+
+// IsLeftShift is a non-type bool: true selects a left-shift state based on
+// signedness of T; false selects ShiftState_RightShift unconditionally.
+template < typename T, bool IsLeftShift > class ShiftMethod
+{
+public:
+    enum
+    {
+        method = !IsLeftShift                            ? ShiftState_RightShift :
+                 std::numeric_limits< T >::is_signed     ? ShiftState_LeftShiftSigned
+                                                         : ShiftState_LeftShiftUnsigned
+    };
+};
+
+template < typename T, typename U, int method > class ShiftHelper;
+
+template < typename T, typename U > class ShiftHelper< T, U, ShiftState_RightShift >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T /*lhs*/, U bits) SAFEINT_NOTHROW
+    {
+        if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+        {
+            if (bits < (int)safeint_internal::int_traits< T >::bitCount)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+template < typename T, typename U > class ShiftHelper< T, U, ShiftState_LeftShiftUnsigned >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T /*lhs*/, U bits) SAFEINT_NOTHROW
+    {
+        if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+        {
+            if (bits < (int)safeint_internal::int_traits< T >::bitCount)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+template < typename T, typename U > class ShiftHelper< T, U, ShiftState_LeftShiftSigned >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T lhs, U bits) SAFEINT_NOTHROW
+    {
+        if (!bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+            return false;
+
+        if (bits >= (int)safeint_internal::int_traits< T >::bitCount - 1)
+            return false;
+
+        typedef typename std::make_unsigned< T >::type UT;
+        return (UT)lhs <= (UT)(std::numeric_limits< T >::max() >> bits);
+    }
+};
 
 /*****************  External functions ****************************************/
 
@@ -6027,7 +6110,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int << bits));
         }
@@ -6038,7 +6121,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int << (U)bits));
         }
@@ -6050,7 +6133,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
         {
             m_int <<= bits;
             return *this;
@@ -6062,7 +6145,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
         {
             m_int <<= (U)bits;
             return *this;
@@ -6075,7 +6158,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int >> bits));
         }
@@ -6086,7 +6169,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int >> (U)bits));
         }
@@ -6098,7 +6181,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
         {
             m_int >>= bits;
             return *this;
@@ -6110,7 +6193,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
         {
             m_int >>= (U)bits;
             return *this;
@@ -6966,7 +7049,7 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (valid_bitcount<U, T>(bits))
+    if (ShiftHelper< U, T, ShiftMethod< U, true >::method >::ValidBitcount(lhs, bits))
     {
         return SafeInt< U, E >((U)(lhs << (T)bits));
     }
@@ -6978,7 +7061,7 @@ SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) S
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (valid_bitcount<U, T>(bits))
+    if (ShiftHelper< U, T, ShiftMethod< U, false >::method >::ValidBitcount(lhs, bits))
     {
         return SafeInt< U, E >((U)(lhs >> (T)bits));
     }

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -3,7 +3,7 @@
 
 /*-----------------------------------------------------------------------------------------------------------
 SafeInt.hpp
-Version 3.0.28p
+Version 3.0.29p
 
 This header implements an integer handling class designed to catch
 unsafe integer operations

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5395,6 +5395,64 @@ public:
     }
 };
 
+// Tag-dispatched test for "is this value negative?" that does not write the
+// `lhs < 0` comparison when T is unsigned.  Avoids the compile-time-constant-
+// conditional warnings (e.g. MSVC C4127) that would otherwise fire on the
+// dead unsigned branch of any caller that handles both signed and unsigned T
+// through one template body.
+template < typename T, int is_signed > class lhs_is_negative;
+
+// Signed case
+template < typename T > class lhs_is_negative < T, true >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool value(T lhs)
+    {
+        return lhs < 0;
+    }
+};
+
+// Unsigned case
+template < typename T > class lhs_is_negative < T, false >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool value(T)
+    {
+        return false;
+    }
+};
+
+// Performs the alignment addition and mask in a way that avoids signed-
+// overflow UB.  For signed T the addition (m_int + AlignValue) overflows
+// when m_int is near max(T), which is undefined behavior; perform the
+// addition in the unsigned counterpart of T so the wrap is well-defined,
+// then cast back.  The post-check in the caller will detect the wrap by
+// observing m_int <= 0.  For unsigned T no special handling is needed
+// (wraparound is already well-defined), but the parallel specialization
+// keeps the call-site warning-clean across both signednesses.
+template < typename T, int is_signed > class align_addmask;
+
+// Signed T
+template < typename T > class align_addmask < T, true >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static T value( T lhs, T align_value )
+    {
+        typedef typename std::make_unsigned< T >::type UT;
+        return (T)( ( (UT)lhs + (UT)align_value ) & ~(UT)align_value );
+    }
+};
+
+// Unsigned T
+template < typename T > class align_addmask < T, false >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static T value( T lhs, T align_value )
+    {
+        return (T)( ( lhs + align_value ) & ~align_value );
+    }
+};
+
 // Shift validation uses the enum-dispatch pattern used elsewhere in this file
 // (see BinaryMethod / BinaryAndHelper, AdditionMethod / AdditionHelper, etc.):
 // a compile-time enum value is computed from properties of T, and a helper
@@ -6360,22 +6418,32 @@ public:
     template < alignBits bits >
     const SafeInt< T, E >& Align() SAFEINT_CPP_THROW
     {
+        // Can't align unsigned numbers on bitCount (e.g., 8 bits = 256, unsigned char max = 255)
+        // or signed numbers on bitCount-1 (e.g., 7 bits = 128, signed char max = 127).
+        // Also makes no sense to try to align on negative or no bits.
+        static_assert( bits >= 0, "Cannot align on a negative bit count" );
+        static_assert(
+            std::numeric_limits< T >::is_signed
+                ? bits < (int)safeint_internal::int_traits< T >::bitCount - 1
+                : bits < (int)safeint_internal::int_traits< T >::bitCount,
+            "Alignment bit count is too large for type T" );
+
         // Zero is always aligned
         if( m_int == 0 )
             return *this;
 
-        // We don't support aligning negative numbers at this time
-        // Can't align unsigned numbers on bitCount (e.g., 8 bits = 256, unsigned char max = 255)
-        // or signed numbers on bitCount-1 (e.g., 7 bits = 128, signed char max = 127).
-        // Also makes no sense to try to align on negative or no bits.
-
-        ShiftAssert( ( ( std::numeric_limits< T >::is_signed && bits < (int)safeint_internal::int_traits< T >::bitCount - 1 )
-                    || ( !std::numeric_limits< T >::is_signed && bits < (int)safeint_internal::int_traits< T >::bitCount ) ) &&
-                    bits >= 0 && ( !std::numeric_limits< T >::is_signed || m_int > 0 ) );
+        // We don't support aligning negative numbers.  The post-mask check
+        // below would usually catch a negative result, but only by relying
+        // on signed-overflow UB to wrap predictably -- so reject up front.
+        if( lhs_is_negative< T, std::numeric_limits< T >::is_signed >::value( m_int ) )
+            E::SafeIntOnOverflow();
 
         const T AlignValue = ( (T)1 << bits ) - 1;
 
-        m_int = (T)( ( m_int + AlignValue ) & ~AlignValue );
+        // Perform the addition in unsigned for signed T to avoid the
+        // signed-overflow UB on (m_int + AlignValue) near max(T).  The
+        // post-check below will still detect the wrap.
+        m_int = align_addmask< T, std::numeric_limits< T >::is_signed >::value( m_int, AlignValue );
 
         if( m_int <= 0 )
             E::SafeIntOnOverflow();

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5395,102 +5395,19 @@ public:
     }
 };
 
-// Shift validation uses the enum-dispatch pattern used elsewhere in this file
-// (see BinaryMethod / BinaryAndHelper, AdditionMethod / AdditionHelper, etc.):
-// a compile-time enum value is computed from properties of T, and a helper
-// class template is specialized on that enum to perform the validation.
-//
-// Three states cover the shift rules:
-//
-//   ShiftState_RightShift
-//       Any T.  The lhs value does not affect well-definedness of >> on any
-//       supported platform; only the bit count needs to be in [0, bitCount<T>).
-//
-//   ShiftState_LeftShiftUnsigned
-//       Unsigned T.  Wraparound is well-defined; only the bit count matters,
-//       same range as right shift.
-//
-//   ShiftState_LeftShiftSigned
-//       Signed T.  Bit count must be in [0, bitCount<T> - 1), AND the lhs
-//       value must not have any bits set that would shift into or past the
-//       sign bit.  Shifting a negative signed value, or shifting a positive
-//       value into the sign bit, is undefined behavior pre-C++20.
-//
-// The signed-left-shift value check uses an unsigned-cast trick to fold both
-// failure modes (negative lhs, and positive lhs that would overflow into the
-// sign bit) into one comparison: a negative lhs casts to a large unsigned
-// value that exceeds the threshold, and a too-large positive lhs fails
-// directly.
-
-enum ShiftState
+template < typename T, typename U > 
+SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 bool valid_bitcount(U bits)
 {
-    ShiftState_RightShift,
-    ShiftState_LeftShiftUnsigned,
-    ShiftState_LeftShiftSigned
-};
-
-// IsLeftShift is a non-type bool: true selects a left-shift state based on
-// signedness of T; false selects ShiftState_RightShift unconditionally.
-template < typename T, bool IsLeftShift > class ShiftMethod
-{
-public:
-    enum
+    if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
     {
-        method = !IsLeftShift                            ? ShiftState_RightShift :
-                 std::numeric_limits< T >::is_signed     ? ShiftState_LeftShiftSigned
-                                                         : ShiftState_LeftShiftUnsigned
-    };
-};
-
-template < typename T, typename U, int method > class ShiftHelper;
-
-template < typename T, typename U > class ShiftHelper< T, U, ShiftState_RightShift >
-{
-public:
-    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T /*lhs*/, U bits) SAFEINT_NOTHROW
-    {
-        if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+        if (bits < (int)safeint_internal::int_traits< T >::bitCount)
         {
-            if (bits < (int)safeint_internal::int_traits< T >::bitCount)
-            {
-                return true;
-            }
+            return true;
         }
-        return false;
     }
-};
 
-template < typename T, typename U > class ShiftHelper< T, U, ShiftState_LeftShiftUnsigned >
-{
-public:
-    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T /*lhs*/, U bits) SAFEINT_NOTHROW
-    {
-        if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
-        {
-            if (bits < (int)safeint_internal::int_traits< T >::bitCount)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-};
-
-template < typename T, typename U > class ShiftHelper< T, U, ShiftState_LeftShiftSigned >
-{
-public:
-    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T lhs, U bits) SAFEINT_NOTHROW
-    {
-        if (!bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
-            return false;
-
-        if (bits >= (int)safeint_internal::int_traits< T >::bitCount - 1)
-            return false;
-
-        typedef typename std::make_unsigned< T >::type UT;
-        return (UT)lhs <= (UT)(std::numeric_limits< T >::max() >> bits);
-    }
-};
+    return false;
+}
 
 /*****************  External functions ****************************************/
 
@@ -6110,7 +6027,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             return SafeInt< T, E >((T)(m_int << bits));
         }
@@ -6121,7 +6038,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             return SafeInt< T, E >((T)(m_int << (U)bits));
         }
@@ -6133,7 +6050,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             m_int <<= bits;
             return *this;
@@ -6145,7 +6062,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, true >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             m_int <<= (U)bits;
             return *this;
@@ -6158,7 +6075,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             return SafeInt< T, E >((T)(m_int >> bits));
         }
@@ -6169,7 +6086,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             return SafeInt< T, E >((T)(m_int >> (U)bits));
         }
@@ -6181,7 +6098,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             m_int >>= bits;
             return *this;
@@ -6193,7 +6110,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (ShiftHelper< T, U, ShiftMethod< T, false >::method >::ValidBitcount(m_int, bits))
+        if (valid_bitcount<T, U>(bits))
         {
             m_int >>= (U)bits;
             return *this;
@@ -7049,7 +6966,7 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (ShiftHelper< U, T, ShiftMethod< U, true >::method >::ValidBitcount(lhs, bits))
+    if (valid_bitcount<U, T>(bits))
     {
         return SafeInt< U, E >((U)(lhs << (T)bits));
     }
@@ -7061,7 +6978,7 @@ SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) S
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (ShiftHelper< U, T, ShiftMethod< U, false >::method >::ValidBitcount(lhs, bits))
+    if (valid_bitcount<U, T>(bits))
     {
         return SafeInt< U, E >((U)(lhs >> (T)bits));
     }

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -6966,7 +6966,7 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
 {
-    if (valid_bitcount<T, U>(bits))
+    if (valid_bitcount<U, T>(bits))
     {
         return SafeInt< U, E >((U)(lhs << (T)bits));
     }
@@ -6978,7 +6978,7 @@ SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) S
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
 {
-    if (valid_bitcount<T, U>(bits))
+    if (valid_bitcount<U, T>(bits))
     {
         return SafeInt< U, E >((U)(lhs >> (T)bits));
     }

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -5395,19 +5395,96 @@ public:
     }
 };
 
-template < typename T, typename U > 
-SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 bool valid_bitcount(U bits)
-{
-    if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
-    {
-        if (bits < (int)safeint_internal::int_traits< T >::bitCount)
-        {
-            return true;
-        }
-    }
+// Shift validation uses the enum-dispatch pattern used elsewhere in this file
+// (see BinaryMethod / BinaryAndHelper, AdditionMethod / AdditionHelper, etc.):
+// a compile-time enum value is computed from properties of T, and a helper
+// class template is specialized on that enum to perform the validation.
+//
+// Three states cover the shift rules:
+//
+//   ShiftState_RightShift
+//       Any T.  The lhs value does not affect well-definedness of >> on any
+//       supported platform; only the bit count needs to be in [0, bitCount<T>).
+//
+//   ShiftState_LeftShiftUnsigned
+//       Unsigned T.  Wraparound is well-defined; only the bit count matters,
+//       same range as right shift.
+//
+//   ShiftState_LeftShiftSigned
+//       Signed T.  Bit count must be in [0, bitCount<T> - 1), AND the lhs
+//       value must not have any bits set that would shift into or past the
+//       sign bit.  Shifting a negative signed value, or shifting a positive
+//       value into the sign bit, is undefined behavior pre-C++20.
+//
+// The signed-left-shift value check uses an unsigned-cast trick to fold both
+// failure modes (negative lhs, and positive lhs that would overflow into the
+// sign bit) into one comparison: a negative lhs casts to a large unsigned
+// value that exceeds the threshold, and a too-large positive lhs fails
+// directly.
 
-    return false;
-}
+enum ShiftState
+{
+    ShiftState_RightShift,
+    ShiftState_LeftShiftUnsigned,
+    ShiftState_LeftShiftSigned
+};
+
+// IsLeftShift is a non-type bool: true selects a left-shift state based on
+// signedness of T; false selects ShiftState_RightShift unconditionally.
+// ShiftMethod exposes both a 3-valued enum (which documents the three rule
+// sets) and a 2-valued bool (which drives ShiftHelper's specialization,
+// since ShiftState_RightShift and ShiftState_LeftShiftUnsigned share an
+// identical implementation -- only the signed-left-shift case differs).
+template < typename T, bool IsLeftShift > class ShiftMethod
+{
+public:
+    enum
+    {
+        method = !IsLeftShift                            ? ShiftState_RightShift :
+                 std::numeric_limits< T >::is_signed     ? ShiftState_LeftShiftSigned
+                                                         : ShiftState_LeftShiftUnsigned,
+
+        isSignedLeftShift = (method == ShiftState_LeftShiftSigned)
+    };
+};
+
+template < typename T, typename U, bool isSignedLeftShift > class ShiftHelper;
+
+// Right shift, and unsigned left shift: only the bit count matters.
+template < typename T, typename U > class ShiftHelper< T, U, false >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T /*lhs*/, U bits) SAFEINT_NOTHROW
+    {
+        if (bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+        {
+            if (bits < (int)safeint_internal::int_traits< T >::bitCount)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+// Signed left shift: tighter bit-count cap (bitCount - 1), plus an
+// unsigned-cast value check that folds the negative-lhs and overflow-into-
+// sign-bit cases into a single comparison.
+template < typename T, typename U > class ShiftHelper< T, U, true >
+{
+public:
+    SAFE_INT_NODISCARD SAFEINT_CONSTEXPR14 static bool ValidBitcount(T lhs, U bits) SAFEINT_NOTHROW
+    {
+        if (!bits_not_negative<U, std::numeric_limits< U >::is_signed>::value(bits))
+            return false;
+
+        if (bits >= (int)safeint_internal::int_traits< T >::bitCount - 1)
+            return false;
+
+        typedef typename std::make_unsigned< T >::type UT;
+        return (UT)lhs <= (UT)(std::numeric_limits< T >::max() >> bits);
+    }
+};
 
 /*****************  External functions ****************************************/
 
@@ -6027,7 +6104,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int << bits));
         }
@@ -6038,7 +6115,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int << (U)bits));
         }
@@ -6050,7 +6127,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             m_int <<= bits;
             return *this;
@@ -6062,7 +6139,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, true >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             m_int <<= (U)bits;
             return *this;
@@ -6075,7 +6152,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int >> bits));
         }
@@ -6086,7 +6163,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             return SafeInt< T, E >((T)(m_int >> (U)bits));
         }
@@ -6098,7 +6175,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             m_int >>= bits;
             return *this;
@@ -6110,7 +6187,7 @@ public:
     template < typename U >
     SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
-        if (valid_bitcount<T, U>(bits))
+        if (ShiftHelper< T, U, ShiftMethod< T, false >::isSignedLeftShift >::ValidBitcount(m_int, bits))
         {
             m_int >>= (U)bits;
             return *this;
@@ -6966,7 +7043,7 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (valid_bitcount<U, T>(bits))
+    if (ShiftHelper< U, T, ShiftMethod< U, true >::isSignedLeftShift >::ValidBitcount(lhs, bits))
     {
         return SafeInt< U, E >((U)(lhs << (T)bits));
     }
@@ -6978,7 +7055,7 @@ SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) S
 template < typename T, typename U, typename E >
 SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
-    if (valid_bitcount<U, T>(bits))
+    if (ShiftHelper< U, T, ShiftMethod< U, false >::isSignedLeftShift >::ValidBitcount(lhs, bits))
     {
         return SafeInt< U, E >((U)(lhs >> (T)bits));
     }

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -6025,7 +6025,7 @@ public:
     // Left shift
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( U bits ) const SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6036,7 +6036,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator <<( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6048,7 +6048,7 @@ public:
     // Left shift assignment
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( U bits ) SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6060,7 +6060,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator <<=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6073,7 +6073,7 @@ public:
 
     // Right shift
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( U bits ) const SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6084,7 +6084,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E > operator >>( SafeInt< U, E > bits ) const SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6096,7 +6096,7 @@ public:
 
     // Right shift assignment
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( U bits ) SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6108,7 +6108,7 @@ public:
     }
 
     template < typename U >
-    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_NOTHROW
+    SAFEINT_CONSTEXPR14 SafeInt< T, E >& operator >>=( SafeInt< U, E > bits ) SAFEINT_CPP_THROW
     {
         if (valid_bitcount<T, U>(bits))
         {
@@ -6854,14 +6854,14 @@ SAFEINT_CONSTEXPR14 T& operator |=( T& lhs, SafeInt< U, E > rhs ) SAFEINT_NOTHRO
 }
 
 template < typename T, typename U, typename E >
-SAFEINT_CONSTEXPR14 T& operator <<=( T& lhs, SafeInt< U, E > rhs ) SAFEINT_NOTHROW
+SAFEINT_CONSTEXPR14 T& operator <<=( T& lhs, SafeInt< U, E > rhs ) SAFEINT_CPP_THROW
 {
     lhs = (T)( SafeInt< T, E >( lhs ) << (U)rhs );
     return lhs;
 }
 
 template < typename T, typename U, typename E >
-SAFEINT_CONSTEXPR14 T& operator >>=( T& lhs, SafeInt< U, E > rhs ) SAFEINT_NOTHROW
+SAFEINT_CONSTEXPR14 T& operator >>=( T& lhs, SafeInt< U, E > rhs ) SAFEINT_CPP_THROW
 {
     lhs = (T)( SafeInt< T, E >( lhs ) >> (U)rhs );
     return lhs;
@@ -6964,7 +6964,7 @@ SAFEINT_CONSTEXPR14 T*& operator >>=( T*& lhs, SafeInt< U, E > ) SAFEINT_NOTHROW
 
 // Left shift
 template < typename T, typename U, typename E >
-SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
+SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
     if (valid_bitcount<U, T>(bits))
     {
@@ -6976,7 +6976,7 @@ SAFEINT_CONSTEXPR14 SafeInt< U, E > operator <<( U lhs, SafeInt< T, E > bits ) S
 
 // Right shift
 template < typename T, typename U, typename E >
-SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_NOTHROW
+SAFEINT_CONSTEXPR14 SafeInt< U, E > operator >>( U lhs, SafeInt< T, E > bits ) SAFEINT_CPP_THROW
 {
     if (valid_bitcount<U, T>(bits))
     {

--- a/Test/AlignVerify.cpp
+++ b/Test/AlignVerify.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) David LeBlanc. All rights reserved.
+// Licensed under the MIT License.
+
+// AlignVerify - exercises the SafeInt<T,E>::Align<bits>() member.
+//
+// Align is a small, niche operation: round a non-negative value up to the
+// next multiple of 2^bits, throwing on overflow or negative input.  It has
+// three observable behaviors:
+//
+//   1. Zero in -> zero out (early return).
+//   2. Negative signed input -> throw.
+//   3. Otherwise -> round up; throw if the rounded value exceeds max(T).
+//
+// The implementation has two ShiftHelper-style specializations (signed and
+// unsigned) for align_addmask, and a static_assert guard on the bits value.
+// We test each behavior with a handful of explicit cases per integer width.
+//
+// IMPORTANT: To validate the signed-overflow fix in align_addmask, build
+// this file with UBSan (gcc/clang: -fsanitize=undefined).  The original
+// bug was that (m_int + AlignValue) was signed-overflow UB near max(T);
+// current compilers happen to wrap predictably and the post-mask check
+// catches the result, so the functional test passes either way.  Only
+// UBSan can distinguish "well-defined unsigned wrap" (correct) from
+// "undefined-but-happens-to-do-the-right-thing" (regression).
+
+#include "TestMain.h"
+#include "TestCase.h"
+
+#if SAFEINT_EXCEPTION_HANDLER_CPP != 1
+#error "AlignVerify requires SAFEINT_EXCEPTION_HANDLER_CPP=1."
+#endif
+#if defined SAFEINT_REMOVE_NOTHROW
+#error "AlignVerify validates throw decorations; do not define SAFEINT_REMOVE_NOTHROW."
+#endif
+
+namespace align_verify
+{
+
+static int g_errors = 0;
+
+// expect_value: value that .Align<Bits>() should return on success.
+// expect_throw: true if Align should throw SafeIntException.
+// (At most one of these is meaningful: when expect_throw is true,
+// expect_value is ignored.)
+template <typename T, int Bits>
+static void check(T lhs, T expect_value, bool expect_throw, const char* label)
+{
+    bool threw = false;
+    T got = 0;
+    try
+    {
+        SafeInt<T> a = lhs;
+        a.template Align<(typename SafeInt<T>::alignBits)Bits>();
+        got = (T)a;
+    }
+    catch (const SafeIntException&)
+    {
+        threw = true;
+    }
+    catch (...)
+    {
+        std::cerr << "AlignVerify FAIL [" << label << "] unexpected exception type" << std::endl;
+        ++g_errors;
+        return;
+    }
+
+    if (threw != expect_throw)
+    {
+        std::cerr << "AlignVerify FAIL [" << label << "] threw=" << threw
+                  << " expected_throw=" << expect_throw << std::endl;
+        ++g_errors;
+        return;
+    }
+    if (!expect_throw && got != expect_value)
+    {
+        std::cerr << "AlignVerify FAIL [" << label << "] got=" << to_hex(got)
+                  << " expected=" << to_hex(expect_value) << std::endl;
+        ++g_errors;
+    }
+}
+
+void AlignVerify()
+{
+    std::cout << "Verifying Align:" << std::endl;
+    g_errors = 0;
+
+    // ---- Behavior 1: zero in -> zero out (early return). ----
+    check<std::int32_t,  4>( 0,  0, false, "i32(0).Align<align16>");
+    check<std::uint32_t, 4>( 0,  0, false, "u32(0).Align<align16>");
+    check<std::int8_t,   1>( 0,  0, false, "i8(0).Align<align2>");
+    check<std::uint64_t, 8>( 0,  0, false, "u64(0).Align<align256>");
+
+    // ---- Behavior 2: negative signed input -> throw. ----
+    // Always rejected, regardless of bits.  Since the post-mask check also
+    // catches negative results, a passing test does not by itself prove the
+    // explicit reject path runs -- but it does prove that no negative input
+    // ever produces a non-throwing result.
+    check<std::int32_t, 1>(-1, 0, true, "i32(-1).Align<align2>");
+    check<std::int32_t, 4>(-1, 0, true, "i32(-1).Align<align16>");
+    check<std::int32_t, 4>(std::numeric_limits<std::int32_t>::min(), 0, true, "i32(min).Align<align16>");
+    check<std::int8_t,  1>(-1,   0, true, "i8(-1).Align<align2>");
+    check<std::int8_t,  1>(-100, 0, true, "i8(-100).Align<align2>");
+    check<std::int64_t, 6>(-1,   0, true, "i64(-1).Align<align64>");
+
+    // ---- Behavior 3a: positive input that fits, rounded up correctly. ----
+    // Already-aligned values pass through unchanged.
+    check<std::uint32_t, 2>( 4,    4,    false, "u32(4).Align<align4>");
+    check<std::uint32_t, 4>( 0x10, 0x10, false, "u32(16).Align<align16>");
+    check<std::int32_t,  4>( 0x10, 0x10, false, "i32(16).Align<align16>");
+    // Not-aligned values round up.
+    check<std::uint32_t, 2>(  1,    4, false, "u32(1).Align<align4>");
+    check<std::uint32_t, 2>(  3,    4, false, "u32(3).Align<align4>");
+    check<std::uint32_t, 2>(  5,    8, false, "u32(5).Align<align4>");
+    check<std::uint32_t, 4>(  7,   16, false, "u32(7).Align<align16>");
+    check<std::uint32_t, 4>(0x101, 0x110, false, "u32(0x101).Align<align16>");
+    check<std::int8_t,   1>(  1,    2, false, "i8(1).Align<align2>");
+    check<std::int8_t,   2>(  5,    8, false, "i8(5).Align<align4>");
+
+    // ---- Behavior 3b: positive input near max, fits exactly. ----
+    // Largest aligned value that's representable.
+    check<std::uint32_t, 2>(0xFFFFFFFC, 0xFFFFFFFC, false, "u32(max&~3).Align<align4>");
+    check<std::int32_t,  2>(0x7FFFFFFC, 0x7FFFFFFC, false, "i32(0x7FFFFFFC).Align<align4>");
+    check<std::uint8_t,  2>(0xFC,       0xFC,       false, "u8(0xFC).Align<align4>");
+    check<std::int8_t,   2>(0x7C,       0x7C,       false, "i8(0x7C).Align<align4>");
+
+    // ---- Behavior 3c: positive input near max, rounded up overflows. ----
+    // Unsigned: post-mask check catches the wrap-to-zero.
+    check<std::uint8_t,  2>(0xFD,       0, true, "u8(0xFD).Align<align4>");
+    check<std::uint8_t,  2>(0xFF,       0, true, "u8(0xFF).Align<align4>");
+    check<std::uint32_t, 2>(0xFFFFFFFD, 0, true, "u32(0xFFFFFFFD).Align<align4>");
+    check<std::uint32_t, 2>(0xFFFFFFFF, 0, true, "u32(max).Align<align4>");
+    check<std::uint64_t, 4>(0xFFFFFFFFFFFFFFFFull, 0, true, "u64(max).Align<align16>");
+    // Signed: align_addmask helper does the addition in unsigned, then the
+    // post-mask check sees a negative value (high bit set) and throws.
+    // This is the case that was UB before the unsigned-helper fix.
+    check<std::int32_t, 2>(0x7FFFFFFD, 0, true, "i32(max-2).Align<align4>");
+    check<std::int32_t, 2>(0x7FFFFFFF, 0, true, "i32(max).Align<align4>");
+    check<std::int8_t,  2>(0x7D,       0, true, "i8(125).Align<align4>");
+    check<std::int8_t,  2>(0x7F,       0, true, "i8(max).Align<align4>");
+    check<std::int64_t, 4>(std::numeric_limits<std::int64_t>::max(), 0, true, "i64(max).Align<align16>");
+
+    // ---- Convenience wrappers (Align2..Align256) delegate to Align<>. ----
+    {
+        bool ok = false;
+        try
+        {
+            SafeInt<std::uint32_t> a = 13;
+            a.Align8();
+            ok = ((std::uint32_t)a == 16u);
+        }
+        catch (...) {}
+        if (!ok) { std::cerr << "AlignVerify FAIL: u32(13).Align8() expected 16" << std::endl; ++g_errors; }
+    }
+    {
+        bool ok = false;
+        try
+        {
+            SafeInt<std::uint32_t> a = 0xFFFFFFFD;
+            a.Align4();
+            ok = false;  // should have thrown
+        }
+        catch (const SafeIntException&) { ok = true; }
+        catch (...) {}
+        if (!ok) { std::cerr << "AlignVerify FAIL: u32(max-2).Align4() should throw" << std::endl; ++g_errors; }
+    }
+
+    if (g_errors == 0)
+        std::cout << "  All align checks passed." << std::endl;
+    else
+        std::cerr << "  " << g_errors << " align check(s) failed." << std::endl;
+}
+
+} // namespace align_verify

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(SafeInt_Test
     AddVerify.cpp
+    AlignVerify.cpp
     CastVerify.cpp
     DivVerify.cpp
     IncDecVerify.cpp
@@ -10,6 +11,7 @@ add_executable(SafeInt_Test
     TestMain.cpp
     TestMain.h)
 target_link_libraries(SafeInt_Test PRIVATE SafeInt)
+target_compile_definitions(SafeInt_Test PRIVATE SAFEINT_TEST_ALIGN)
 
 add_executable(SafeInt_CompileTest
     CleanCompile.cpp

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(SafeInt_Test
     IncDecVerify.cpp
     ModVerify.cpp
     MultVerify.cpp
+    ShiftVerify.cpp
     SubVerify.cpp
     TestMain.cpp
     TestMain.h)

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp
@@ -72,6 +73,7 @@ else()
     ../ModVerify.cpp 
     ../MultVerify.cpp 
     ../MultTestCase.cpp
+    ../ShiftVerify.cpp 
     ../SubVerify.cpp 
     ../SubTestCase.cpp
     ../TestMain.cpp
@@ -93,6 +95,7 @@ else()
     ../ModVerify.cpp 
     ../MultVerify.cpp 
     ../MultTestCase.cpp
+    ../ShiftVerify.cpp 
     ../SubVerify.cpp 
     ../SubTestCase.cpp
     ../TestMain.cpp

--- a/Test/ClangTest/CMakeLists.txt
+++ b/Test/ClangTest/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
     add_executable(SafeIntTest_clang 
         ../AddVerify.cpp 
         ../AddTestCase.cpp
+        ../AlignVerify.cpp 
         ../CastVerify.cpp 
         ../DivVerify.cpp 
         ../DivTestCase.cpp
@@ -61,6 +62,7 @@ else()
     )
 
     target_compile_options(SafeIntTest_clang PUBLIC -Werror -fsanitize-trap=undefined)
+    target_compile_definitions(SafeIntTest_clang PRIVATE SAFEINT_TEST_ALIGN)
 
     # Forces use of the older, less efficient code that can't use either int128 or intrinsics
     add_executable(SafeIntTest_clang_NoIntrinsic

--- a/Test/GccTest/CMakeLists.txt
+++ b/Test/GccTest/CMakeLists.txt
@@ -41,6 +41,7 @@ else()
     add_executable(SafeIntTest_gcc 
         ../AddVerify.cpp 
         ../AddTestCase.cpp
+        ../AlignVerify.cpp 
         ../CastVerify.cpp 
         ../DivVerify.cpp 
         ../DivTestCase.cpp
@@ -55,6 +56,7 @@ else()
         ../TestMain.h
         ../../SafeInt.hpp
     )
+    target_compile_definitions(SafeIntTest_gcc PRIVATE SAFEINT_TEST_ALIGN)
 
     # Forces use of the older, less efficient code that can't use either int128 or intrinsics
     add_executable(SafeIntTest_gcc_NoIntrinsic

--- a/Test/GccTest/CMakeLists.txt
+++ b/Test/GccTest/CMakeLists.txt
@@ -48,6 +48,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp
@@ -66,6 +67,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp
@@ -86,6 +88,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp

--- a/Test/MsvcTest/CMakeLists.txt
+++ b/Test/MsvcTest/CMakeLists.txt
@@ -38,6 +38,7 @@ else()
     add_executable(SafeIntTest_msvc 
         ../AddVerify.cpp 
         ../AddTestCase.cpp
+        ../AlignVerify.cpp 
         ../CastVerify.cpp 
         ../DivVerify.cpp 
         ../DivTestCase.cpp
@@ -52,6 +53,7 @@ else()
         ../TestMain.h
         ../../SafeInt.hpp
     )
+    target_compile_definitions(SafeIntTest_msvc PRIVATE SAFEINT_TEST_ALIGN)
     
         # Forces use of the older, less efficient code that can't use either int128 or intrinsics
         add_executable(SafeIntTest_msvc_NoIntrinsic

--- a/Test/MsvcTest/CMakeLists.txt
+++ b/Test/MsvcTest/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp
@@ -63,6 +64,7 @@ else()
         ../ModVerify.cpp 
         ../MultVerify.cpp 
         ../MultTestCase.cpp
+        ../ShiftVerify.cpp 
         ../SubVerify.cpp 
         ../SubTestCase.cpp
         ../TestMain.cpp

--- a/Test/SafeIntTestVS17/Scratch/Scratch.cpp
+++ b/Test/SafeIntTestVS17/Scratch/Scratch.cpp
@@ -13,10 +13,10 @@ Use this to check specific scenarios
 
 int main(int argc, char** argv)
 {
-    std::string s = "12345678";
+    std::uint32_t lhs = 1;            // U = std::uint32_t
+    SafeInt<std::uint64_t> bits = 40; // T = std::uint64_t
 
-    SafeInt<uint64_t> a = 1;
-    int64_t b = 2;
+    auto foo = lhs << bits;
 
-    return a - b;
+    return 0;
 }

--- a/Test/ShiftVerify.cpp
+++ b/Test/ShiftVerify.cpp
@@ -1,0 +1,576 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// ShiftVerify - exercises every code path in the shift validators.
+//
+// Two layers of coverage:
+//
+//   1. Named regression cases for the specific bugs the shift_fix branch
+//      was created to address:
+//        - SAFEINT_NOTHROW on shift operators that can throw (verified by
+//          observing that SafeIntException actually propagates out of every
+//          shift form instead of std::terminate firing).
+//        - Mixed-width free-overload bug (uint32_t lhs << SafeInt<uint64_t>
+//          bits) where the bit-count check was using the wrong type's width.
+//        - Signed left-shift undefined behavior: negative lhs, positive lhs
+//          that overflows into the sign bit, and the canonical 1 << 31.
+//
+//   2. A generated sweep that hits every branch in both ShiftHelper
+//      specializations, across boundary bit counts and lhs values, for
+//      both << and >> in all six call forms (member raw, member SafeInt,
+//      member-assign raw, member-assign SafeInt, free raw lhs, free raw
+//      lhs assign).
+
+#include "TestMain.h"
+#include "TestCase.h"
+
+// This file deliberately depends on C++ exceptions being the configured
+// SafeInt error handler.  Without that, the throw-validation cases would
+// silently no-op and the SAFEINT_NOTHROW->SAFEINT_CPP_THROW fix could
+// regress without detection.
+#if SAFEINT_EXCEPTION_HANDLER_CPP != 1
+#error "ShiftVerify requires SAFEINT_EXCEPTION_HANDLER_CPP=1 to validate throw decorations on shift operators."
+#endif
+
+// Likewise, SAFEINT_REMOVE_NOTHROW would defeat the point of testing the
+// throw decorations -- the operators would carry no throw spec at all,
+// so a regression to noexcept would not be detectable here.
+#if defined SAFEINT_REMOVE_NOTHROW
+#error "ShiftVerify validates that throw decorations on shift operators are correct; do not define SAFEINT_REMOVE_NOTHROW."
+#endif
+
+// Test code sweeps both signed and unsigned T through the same templates,
+// which intentionally leaves dead-code branches whose compile-time-constant
+// conditionals MSVC /W4 flags as C4127.  Likewise, boundary value generation
+// produces (T)-1 for unsigned T, triggering C4146.  Both are expected
+// consequences of using one template body to test both signed and unsigned
+// instantiations.
+#if defined(_MSC_VER)
+#pragma warning(disable: 4127)  // conditional expression is constant
+#pragma warning(disable: 4146)  // unary minus operator applied to unsigned type
+#endif
+
+namespace shift_verify
+{
+
+static int g_errors = 0;
+
+static void report_failure(const char* what)
+{
+    ++g_errors;
+    std::cerr << "ShiftVerify FAIL: " << what << std::endl;
+}
+
+// Helper: run a shift expression that is expected to either succeed with a
+// specific result, or throw SafeIntException.  Returns true if the observed
+// behavior matches the expectation.
+template <typename Expr>
+static bool check_shift(Expr expr, bool expect_throw, const char* label)
+{
+    bool threw = false;
+    try
+    {
+        expr();
+    }
+    catch (const SafeIntException&)
+    {
+        threw = true;
+    }
+    catch (...)
+    {
+        // Any other exception type indicates the throw decoration is wrong
+        // (something escaped that should not have).
+        report_failure(label);
+        return false;
+    }
+
+    if (threw != expect_throw)
+    {
+        report_failure(label);
+        return false;
+    }
+    return true;
+}
+
+//=============================================================================
+// Named regression cases.
+//=============================================================================
+
+static void NamedRegressionCases()
+{
+    std::cout << "  Named regression cases" << std::endl;
+
+    // --- Signed left shift UB: 1 << 31 places 1 in the sign position.
+    check_shift([] {
+        SafeInt<std::int32_t> a = 1;
+        std::int32_t r = a << 31;
+        (void)r;
+    }, true, "int32_t(1) << 31 should throw");
+
+    // --- Signed left shift UB: negative lhs (any bits).
+    check_shift([] {
+        SafeInt<std::int32_t> a = -1;
+        std::int32_t r = a << 1;
+        (void)r;
+    }, true, "int32_t(-1) << 1 should throw");
+
+    // --- Signed left shift UB: positive lhs whose top set bit overflows.
+    check_shift([] {
+        SafeInt<std::int32_t> a = 0x40000000;
+        std::int32_t r = a << 1;
+        (void)r;
+    }, true, "int32_t(0x40000000) << 1 should throw");
+
+    // --- Boundary accept (signed): 0x3FFFFFFF << 1 == 0x7FFFFFFE, fits.
+    {
+        bool ok = false;
+        try
+        {
+            SafeInt<std::int32_t> a = 0x3FFFFFFF;
+            std::int32_t r = a << 1;
+            ok = (r == 0x7FFFFFFE);
+        }
+        catch (...) {}
+        if (!ok) report_failure("int32_t(0x3FFFFFFF) << 1 should accept and equal 0x7FFFFFFE");
+    }
+
+    // --- Did NOT over-restrict: (uint32_t)1 << 31 is well-defined and equals
+    // 0x80000000.  This case must not throw.
+    {
+        bool ok = false;
+        try
+        {
+            SafeInt<std::uint32_t> a = 1;
+            std::uint32_t r = a << 31;
+            ok = (r == 0x80000000u);
+        }
+        catch (...) {}
+        if (!ok) report_failure("uint32_t(1) << 31 should accept and equal 0x80000000");
+    }
+
+    // --- Mixed-width free overload regression: lhs=uint32_t, bits=SafeInt<uint64_t>.
+    // Shift count of 40 exceeds bitCount<uint32_t>=32, must throw.
+    check_shift([] {
+        std::uint32_t lhs = 1;
+        SafeInt<std::uint64_t> bits = 40;
+        auto r = lhs << bits;
+        (void)r;
+    }, true, "uint32_t(1) << SafeInt<uint64_t>(40) should throw");
+
+    // --- Mixed-width free overload, valid shift: lhs=uint32_t, bits=SafeInt<uint64_t>(8).
+    // 8 < 32, valid, result must equal 0x100.
+    {
+        bool ok = false;
+        try
+        {
+            std::uint32_t lhs = 1;
+            SafeInt<std::uint64_t> bits = 8;
+            SafeInt<std::uint32_t, SafeIntDefaultExceptionHandler> r = lhs << bits;
+            ok = ((std::uint32_t)r == 0x100u);
+        }
+        catch (...) {}
+        if (!ok) report_failure("uint32_t(1) << SafeInt<uint64_t>(8) should accept and equal 0x100");
+    }
+
+    // --- Throw-escape coverage: every shift form must let SafeIntException
+    // propagate.  If any of these were still annotated noexcept, std::terminate
+    // would fire and the test process would die -- visible signal.
+    check_shift([] {
+        SafeInt<std::int32_t> a = 1;
+        SafeInt<std::int32_t> r = a << 31;
+        (void)r;
+    }, true, "operator<<(U) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 1;
+        SafeInt<std::int32_t> b = 31;
+        SafeInt<std::int32_t> r = a << b;
+        (void)r;
+    }, true, "operator<<(SafeInt<U>) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 1;
+        a <<= 31;
+    }, true, "operator<<=(U) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 1;
+        SafeInt<std::int32_t> b = 31;
+        a <<= b;
+    }, true, "operator<<=(SafeInt<U>) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 100;
+        SafeInt<std::int32_t> r = a >> 32;
+        (void)r;
+    }, true, "operator>>(U) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 100;
+        SafeInt<std::int32_t> b = 32;
+        SafeInt<std::int32_t> r = a >> b;
+        (void)r;
+    }, true, "operator>>(SafeInt<U>) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 100;
+        a >>= 32;
+    }, true, "operator>>=(U) throw escape");
+
+    check_shift([] {
+        SafeInt<std::int32_t> a = 100;
+        SafeInt<std::int32_t> b = 32;
+        a >>= b;
+    }, true, "operator>>=(SafeInt<U>) throw escape");
+
+    check_shift([] {
+        std::int32_t lhs = 1;
+        SafeInt<std::int32_t> bits = 31;
+        auto r = lhs << bits;
+        (void)r;
+    }, true, "free operator<<(U, SafeInt<T>) throw escape");
+
+    check_shift([] {
+        std::int32_t lhs = 100;
+        SafeInt<std::int32_t> bits = 32;
+        auto r = lhs >> bits;
+        (void)r;
+    }, true, "free operator>>(U, SafeInt<T>) throw escape");
+}
+
+//=============================================================================
+// Generated sweep.
+//
+// Independent oracle: compute the shift in a wide unsigned type, then
+// independently decide whether the result fits in T and whether the input
+// was UB.  The oracle's logic does NOT share code with ShiftHelper; that's
+// the point.
+//=============================================================================
+
+// Promote any integer to uint64_t for the oracle's arithmetic, preserving
+// the value (sign-extending negatives so the bit pattern is preserved on
+// the high side and we can detect "would touch sign bit" cases below).
+template <typename T>
+static std::uint64_t to_u64(T v)
+{
+    // Two-step cast: through the same-width signed/unsigned of T to preserve
+    // the bit pattern, then widen.  For unsigned T this is just a widen.
+    return (std::uint64_t)(typename std::make_unsigned<T>::type)v;
+}
+
+// Oracle for left shift: returns true if the shift is well-defined AND the
+// result is representable in T.  This independently re-derives the rules,
+// matching the C++17 standard's stricter interpretation that SafeInt targets.
+template <typename T, typename U>
+static bool oracle_lshift_valid(T lhs, U bits)
+{
+    // Negative bit count: undefined.
+    if (std::numeric_limits<U>::is_signed && bits < 0) return false;
+    // Bit count >= width: undefined.
+    if ((std::uint64_t)bits >= safeint_internal::int_traits<T>::bitCount) return false;
+
+    if (std::numeric_limits<T>::is_signed)
+    {
+        // Negative signed lhs: undefined pre-C++20.
+        if (lhs < 0) return false;
+        // Bit count >= width-1 with non-zero lhs would touch the sign bit.
+        // (Note: lhs == 0 with bits == width-1 is technically defined, but
+        // the validator caps at width-1 unconditionally for signed; the
+        // oracle matches that intentional choice -- see ShiftVerify state-of-
+        // work doc.)
+        if ((std::uint64_t)bits >= safeint_internal::int_traits<T>::bitCount - 1) return false;
+        // Non-negative signed lhs: result must fit in signed T.
+        std::uint64_t bound = (std::uint64_t)std::numeric_limits<T>::max() >> bits;
+        if ((std::uint64_t)lhs > bound) return false;
+    }
+    return true;
+}
+
+// Oracle for right shift: returns true if well-defined.  Right shift does
+// not depend on the lhs value for well-definedness on any supported target.
+template <typename T, typename U>
+static bool oracle_rshift_valid(T /*lhs*/, U bits)
+{
+    if (std::numeric_limits<U>::is_signed && bits < 0) return false;
+    if ((std::uint64_t)bits >= safeint_internal::int_traits<T>::bitCount) return false;
+    return true;
+}
+
+// For each (T, lhs, bits) tuple where the shift is valid, compute the
+// expected result the same way the oracle reasons about it: cast to
+// unsigned T, do the shift, cast back.  This matches what SafeInt's
+// operator does internally and is well-defined in C++.
+template <typename T, typename U>
+static T expected_lshift(T lhs, U bits)
+{
+    typedef typename std::make_unsigned<T>::type UT;
+    return (T)((UT)lhs << bits);
+}
+
+template <typename T, typename U>
+static T expected_rshift(T lhs, U bits)
+{
+    return (T)(lhs >> bits);
+}
+
+// Run all six << forms for one (T, U, lhs, bits) tuple and verify each
+// matches the oracle.
+template <typename T, typename U>
+static void check_one_lshift(T lhs, U bits, const char* tu_label)
+{
+    bool valid = oracle_lshift_valid<T, U>(lhs, bits);
+    T expected = valid ? expected_lshift<T, U>(lhs, bits) : T(0);
+
+    // Form 1: SafeInt<T>(lhs) << bits  (member, raw U)
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); got = a << bits; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " <<(U)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << " threw=" << threw
+                      << " valid=" << valid << " got=" << to_hex(got)
+                      << " expected=" << to_hex(expected) << std::endl;
+            ++g_errors;
+        }
+    }
+
+    // Form 2: SafeInt<T>(lhs) << SafeInt<U>(bits)  (member, SafeInt U)
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); SafeInt<U> b(bits); got = a << b; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " <<(SafeInt<U>)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+
+    // Form 3: a <<= bits  (member-assign, raw U)
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); a <<= bits; got = (T)a; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " <<=(U)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+
+    // Form 4: a <<= SafeInt<U>(bits)  (member-assign, SafeInt U)
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); SafeInt<U> b(bits); a <<= b; got = (T)a; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " <<=(SafeInt<U>)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+
+    // Form 5: T(lhs) << SafeInt<U>(bits)  (free overload, raw lhs)
+    // The validator for this overload runs over (T = lhs type, U = bits type).
+    // The validity check matches our oracle for the same (T, U).
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<U> b(bits); SafeInt<T> r = lhs << b; got = (T)r; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " free <<] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+
+    // Form 6: T& <<= SafeInt<U>(bits)  (free overload, raw lhs assign)
+    {
+        bool threw = false; T got = 0;
+        try { T x = lhs; SafeInt<U> b(bits); x <<= b; got = x; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " free <<=] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+}
+
+template <typename T, typename U>
+static void check_one_rshift(T lhs, U bits, const char* tu_label)
+{
+    bool valid = oracle_rshift_valid<T, U>(lhs, bits);
+    T expected = valid ? expected_rshift<T, U>(lhs, bits) : T(0);
+
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); got = a >> bits; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " >>(U)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); SafeInt<U> b(bits); got = a >> b; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " >>(SafeInt<U>)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); a >>= bits; got = (T)a; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " >>=(U)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<T> a(lhs); SafeInt<U> b(bits); a >>= b; got = (T)a; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " >>=(SafeInt<U>)] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+    {
+        bool threw = false; T got = 0;
+        try { SafeInt<U> b(bits); SafeInt<T> r = lhs >> b; got = (T)r; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " free >>] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+    {
+        bool threw = false; T got = 0;
+        try { T x = lhs; SafeInt<U> b(bits); x >>= b; got = x; }
+        catch (const SafeIntException&) { threw = true; }
+        if (threw == valid || (valid && got != expected))
+        {
+            std::cerr << "ShiftVerify FAIL [" << tu_label << " free >>=] lhs=" << to_hex(lhs)
+                      << " bits=" << (long long)bits << std::endl;
+            ++g_errors;
+        }
+    }
+}
+
+// Boundary lhs values for one type T.  Eight distinct values that cover
+// zero, near-zero, the just-fits / just-overflows boundary for left shift
+// by 1, the type bounds, and -1 for signed types.
+template <typename T>
+static void boundary_lhs_values(T values[8])
+{
+    typedef typename std::make_unsigned<T>::type UT;
+    UT umax = (UT)std::numeric_limits<T>::max();
+    values[0] = (T)0;
+    values[1] = (T)1;
+    values[2] = (T)(umax >> 1);     // For signed: 0x3FFF... (boundary accept << 1)
+    values[3] = (T)((umax >> 1) + 1); // For signed: 0x4000... (boundary reject << 1)
+    values[4] = std::numeric_limits<T>::max();
+    values[5] = std::numeric_limits<T>::min();
+    values[6] = (T)-1;
+    values[7] = (T)((T)1 << (safeint_internal::int_traits<T>::bitCount - 2)); // mid bit set
+}
+
+// Boundary bit-count values for one (T, U) pair.  Up to seven values:
+// negative (only when U is signed), zero, one, width-2, width-1, width,
+// width+1.  Returns the count actually filled.
+template <typename T, typename U>
+static int boundary_bits_values(U values[7])
+{
+    int count = 0;
+    int width = (int)safeint_internal::int_traits<T>::bitCount;
+    if (std::numeric_limits<U>::is_signed) values[count++] = (U)-1;
+    values[count++] = (U)0;
+    values[count++] = (U)1;
+    values[count++] = (U)(width - 2);
+    values[count++] = (U)(width - 1);
+    values[count++] = (U)(width);
+    // Don't add width+1 if U can't represent it (e.g. U=int8_t and T=int64_t,
+    // then width=64 already overflows int8_t -- but the cast above will have
+    // wrapped; check before adding the +1.)
+    if ((int)(U)(width + 1) == width + 1) values[count++] = (U)(width + 1);
+    return count;
+}
+
+template <typename T, typename U>
+static void SweepShift(const char* tu_label)
+{
+    T lhs_values[8];
+    boundary_lhs_values<T>(lhs_values);
+
+    U bits_values[7];
+    int bits_count = boundary_bits_values<T, U>(bits_values);
+
+    for (size_t i = 0; i < 8; ++i)
+    {
+        for (int j = 0; j < bits_count; ++j)
+        {
+            check_one_lshift<T, U>(lhs_values[i], bits_values[j], tu_label);
+            check_one_rshift<T, U>(lhs_values[i], bits_values[j], tu_label);
+        }
+    }
+}
+
+//=============================================================================
+// Entry point.
+//=============================================================================
+
+void ShiftVerify()
+{
+    std::cout << "Verifying Shift:" << std::endl;
+    g_errors = 0;
+
+    NamedRegressionCases();
+
+    std::cout << "  Generated sweep" << std::endl;
+
+    // Same-width sweep across all eight integer types.
+    SweepShift<std::int8_t,   std::int8_t>("int8/int8");
+    SweepShift<std::int16_t,  std::int16_t>("int16/int16");
+    SweepShift<std::int32_t,  std::int32_t>("int32/int32");
+    SweepShift<std::int64_t,  std::int64_t>("int64/int64");
+    SweepShift<std::uint8_t,  std::uint8_t>("uint8/uint8");
+    SweepShift<std::uint16_t, std::uint16_t>("uint16/uint16");
+    SweepShift<std::uint32_t, std::uint32_t>("uint32/uint32");
+    SweepShift<std::uint64_t, std::uint64_t>("uint64/uint64");
+
+    // Mixed-width and mixed-signedness sweeps on representative T's, to
+    // exercise the free-overload regression and the signed-U branch of
+    // bits_not_negative.
+    SweepShift<std::int32_t,  std::uint64_t>("int32/uint64");
+    SweepShift<std::int32_t,  std::int8_t>("int32/int8");
+    SweepShift<std::uint32_t, std::uint64_t>("uint32/uint64");
+    SweepShift<std::uint32_t, std::int8_t>("uint32/int8");
+
+    if (g_errors == 0)
+        std::cout << "  All shift checks passed." << std::endl;
+    else
+        std::cerr << "  " << g_errors << " shift check(s) failed." << std::endl;
+}
+
+} // namespace shift_verify

--- a/Test/TestMain.cpp
+++ b/Test/TestMain.cpp
@@ -42,5 +42,6 @@ int main(int, char**)
     mod_verify::ModVerify();
     incdec_verify::IncDecVerify();
     negation_verify::NegationVerify();
+    shift_verify::ShiftVerify();
     return 0;
 }

--- a/Test/TestMain.cpp
+++ b/Test/TestMain.cpp
@@ -43,5 +43,8 @@ int main(int, char**)
     incdec_verify::IncDecVerify();
     negation_verify::NegationVerify();
     shift_verify::ShiftVerify();
+#if defined SAFEINT_TEST_ALIGN
+    align_verify::AlignVerify();
+#endif
     return 0;
 }

--- a/Test/TestMain.h
+++ b/Test/TestMain.h
@@ -31,4 +31,7 @@ namespace incdec_verify { void IncDecVerify(); }
 namespace cast_verify { void CastVerify(); }
 namespace negation_verify { void NegationVerify(); }
 namespace shift_verify { void ShiftVerify(); }
+#if defined SAFEINT_TEST_ALIGN
+namespace align_verify { void AlignVerify(); }
+#endif
 

--- a/Test/TestMain.h
+++ b/Test/TestMain.h
@@ -30,4 +30,5 @@ namespace mod_verify { void ModVerify(); }
 namespace incdec_verify { void IncDecVerify(); }
 namespace cast_verify { void CastVerify(); }
 namespace negation_verify { void NegationVerify(); }
+namespace shift_verify { void ShiftVerify(); }
 


### PR DESCRIPTION
Fix Align UB and add explicit negative-input rejection (closes #N)

Replaces the body of SafeInt::Align with three layered defenses:

1. A static_assert on the helper class template lhs_is_negative, which
   eliminates the latent reference to the never-defined ShiftAssert
   macro that lived in the previous body.  Only MSVC's loose two-phase
   template lookup let the missing identifier through; gcc and clang
   would have rejected it once the template was instantiated.

2. An explicit runtime check that throws SafeIntException for negative
   m_int values.  The previous "round up to next aligned address"
   semantics are not meaningful for negative values, and the previous
   bit-twiddling computation produced silently-wrong results for them.

3. The (m_int + AlignValue) addition is now performed via a new
   align_addmask helper class template that does the arithmetic in the
   unsigned counterpart of T.  This eliminates signed-overflow UB when
   m_int is close to max(T).  The post-mask check catches the
   overflow as before.

Adds AlignVerify.cpp covering the three new behaviors (zero shortcut,
negative input rejection, round-up-or-overflow boundary cases) across
every supported integer type.  AlignVerify is wired into the default
runtime test target only -- alignment is not part of the C/C++ parity
surface, so the _NoIntrinsic and _NoInt128 variants don't include it.
The new test is gated on SAFEINT_TEST_ALIGN in TestMain.cpp.

The functional behavior change is visible only on signed input near
max(T) and on negative input.  Existing callers passing positive
in-range values get identical results.

Verified clean on gcc 13.3 and clang 18 at -O0/-O2/-O3 with UBSan.