### PR TITLE
Fix #81: add ShiftVerify.cpp to makefiles and Visual Studio project f…

### DIFF
--- a/Test/ClangTest/makefile
+++ b/Test/ClangTest/makefile
@@ -10,14 +10,14 @@ clean:
 	rm -f CompileTest14
 	rm -f *.err
 
-SafeIntTest: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	clang++ --std=c++11 -O3 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
+SafeIntTest: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	clang++ --std=c++11 -O3 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
 
-SafeIntTest_NoIntrinsic: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	clang++ --std=c++11 -O3 -D SAFEINT_USE_INTRINSICS=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest_NoIntrinsic 2> SafeIntTest_NoIntrinsic.err
+SafeIntTest_NoIntrinsic: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	clang++ --std=c++11 -O3 -D SAFEINT_USE_INTRINSICS=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest_NoIntrinsic 2> SafeIntTest_NoIntrinsic.err
 
-SafeIntTest_NoInt128: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	clang++ --std=c++11 -O3 -D SAFEINT_HAS_INT128=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest_NoInt128 2> SafeIntTest_NoInt128.err
+SafeIntTest_NoInt128: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	clang++ --std=c++11 -O3 -D SAFEINT_HAS_INT128=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest_NoInt128 2> SafeIntTest_NoInt128.err
 
 CompileTest98: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	clang++ -Wall -D SAFEINT_USE_CPLUSCPLUS_98 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest 2> CompileTest.err

--- a/Test/GccTest/makefile
+++ b/Test/GccTest/makefile
@@ -11,14 +11,14 @@ clean:
 	rm -f *.err
 
 
-SafeIntTest: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	g++ --std=c++11 -O3 ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
+SafeIntTest: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	g++ --std=c++11 -O3 ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
 
-SafeIntTest_NoIntrinsic: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	g++ --std=c++11 -O3 -D SAFEINT_USE_INTRINSICS=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest_NoIntrinsic 2> SafeIntTest_NoIntrinsic.err
+SafeIntTest_NoIntrinsic: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	g++ --std=c++11 -O3 -D SAFEINT_USE_INTRINSICS=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest_NoIntrinsic 2> SafeIntTest_NoIntrinsic.err
 
-SafeIntTest_NoInt128: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	g++ --std=c++11 -O3 -D SAFEINT_HAS_INT128=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest_NoInt128 2> SafeIntTest_NoInt128.err
+SafeIntTest_NoInt128: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
+	g++ --std=c++11 -O3 -D SAFEINT_HAS_INT128=0 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../ShiftVerify.cpp ../TestMain.cpp -o SafeIntTest_NoInt128 2> SafeIntTest_NoInt128.err
 
 CompileTest: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	g++ -Wall --std=c++11 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest 2> CompileTest.err

--- a/Test/SafeIntTest/SafeIntTest.vcxproj
+++ b/Test/SafeIntTest/SafeIntTest.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="..\ModVerify.cpp" />
     <ClCompile Include="..\MultVerify.cpp" />
     <ClCompile Include="..\SubVerify.cpp" />
+    <ClCompile Include="..\ShiftVerify.cpp" />
     <ClCompile Include="..\TestMain.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/SafeIntTest/SafeIntTest.vcxproj.filters
+++ b/Test/SafeIntTest/SafeIntTest.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="..\SubVerify.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ShiftVerify.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\TestMain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj
+++ b/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="..\..\MultVerify.cpp" />
     <ClCompile Include="..\..\SubTestCase.cpp" />
     <ClCompile Include="..\..\SubVerify.cpp" />
+    <ClCompile Include="..\..\ShiftVerify.cpp" />
     <ClCompile Include="..\..\TestMain.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj.filters
+++ b/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="..\..\SubVerify.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ShiftVerify.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\TestMain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
…iles

ShiftVerify.cpp was added to the CMake build files but not to the hand-maintained makefiles (Test/GccTest, Test/ClangTest) or the Visual Studio project files (SafeIntTest, SafeIntTestVS17). The shift verification step was therefore not being compiled or linked on those build paths.

Adds the file consistently across all six remaining build files, matching the existing pattern for SubVerify.cpp.

Verified on gcc 13.3 and clang 18.1; all three SafeIntTest variants (default, NoIntrinsic, NoInt128) now build and pass, including the shift verification section.