### PR TITLE
Fix #83: reject SafeInt<__int128> and other oversized integer types

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -648,6 +648,7 @@ namespace safeint_internal
     {
     public:
         static_assert(safeint_internal::numeric_type< T >::isInt, "Integer type required");
+        static_assert(sizeof(T) <= 8, "SafeInt supports integer types up to 64 bits");
 
         enum
         {


### PR DESCRIPTION
SafeInt<__int128> previously compiled silently under gcc and clang in gnu++ mode, because std::is_integral<__int128> is true in that mode and the existing static_assert in int_traits<T> only checks the integral trait. The resulting SafeInt had all int_traits size enums (isInt8... isInt64) evaluate to false because sizeof(__int128) == 16 matches none of them, silently producing wrong code.

Add a second static_assert that sizeof(T) <= 8 immediately after the existing isInt check in int_traits. This catches __int128, unsigned __int128, and any future oversized integer type a compiler might offer.

The static_assert is placed in int_traits because every SafeInt operation instantiates it; the four duplicate "Integer type required" asserts in SafeInt's constructors don't need updating because reaching them also instantiates int_traits and trips this check first.

__int128 remains in use internally as an implementation detail for some 64-bit operations; only its use as a SafeInt template parameter is rejected.

Verified on gcc 13.3 and clang 18.1; the full test suite passes via both the GccTest and ClangTest makefiles.