### PR TITLE
Gcc int128 warning

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -249,6 +249,8 @@ We can check for these with:
 
 #if defined __SIZEOF_INT128__ && __SIZEOF_INT128__ == 16
 #define SAFEINT_HAS_INT128 1
+__extension__ typedef          __int128 safeint_int128_t;
+__extension__ typedef unsigned __int128 safeint_uint128_t;
 #else
 #define SAFEINT_HAS_INT128 0
 #endif
@@ -1750,7 +1752,7 @@ template < typename T, typename U > class LargeIntRegMultiply;
 
 SAFEINT_CONSTEXPR14 inline bool MultiplyUint64(std::uint64_t a, std::uint64_t b, std::uint64_t* pRet) SAFEINT_NOTHROW
 {
-    unsigned __int128 tmp = (unsigned __int128)a * (unsigned __int128)b;
+    safeint_uint128_t tmp = (unsigned __int128)a * (unsigned __int128)b;
 
     if ((tmp >> 64) == 0)
     {
@@ -1763,9 +1765,9 @@ SAFEINT_CONSTEXPR14 inline bool MultiplyUint64(std::uint64_t a, std::uint64_t b,
 
 SAFEINT_CONSTEXPR14 inline bool MultiplyInt64(std::int64_t a, std::int64_t b, std::int64_t* pRet) SAFEINT_NOTHROW
 {
-    __int128 tmp = (__int128)a * (__int128)b;
+    safeint_int128_t tmp = (safeint_int128_t)a * (safeint_int128_t)b;
     *pRet = (std::int64_t)tmp;
-    std::int64_t tmp_high = (std::int64_t)((unsigned __int128)tmp >> 64);
+    std::int64_t tmp_high = (std::int64_t)((safeint_uint128_t)tmp >> 64);
 
     // If only one input is negative, result must be negative, or zero
     if( (a ^ b) < 0 )

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -1752,7 +1752,7 @@ template < typename T, typename U > class LargeIntRegMultiply;
 
 SAFEINT_CONSTEXPR14 inline bool MultiplyUint64(std::uint64_t a, std::uint64_t b, std::uint64_t* pRet) SAFEINT_NOTHROW
 {
-    safeint_uint128_t tmp = (unsigned __int128)a * (unsigned __int128)b;
+    safeint_uint128_t tmp = (safeint_uint128_t)a * (safeint_uint128_t)b;
 
     if ((tmp >> 64) == 0)
     {

--- a/Test/ModVerify.cpp
+++ b/Test/ModVerify.cpp
@@ -27,7 +27,7 @@ namespace mod_verify
 template<typename T>
 struct ModVerifyTest1
 {
-	ModVerifyTest1<T>()
+	ModVerifyTest1()
 	{
 		const size_t width = sizeof(T);
 		const size_t shift = width * CHAR_BIT - 1;
@@ -83,7 +83,7 @@ struct ModVerifyTest1
 template<typename T>
 struct ModVerifyTest2
 {
-	ModVerifyTest2<T>()
+	ModVerifyTest2()
 	{
 		const size_t width = sizeof(T);
 		const size_t shift = width * CHAR_BIT - 1;


### PR DESCRIPTION
gcc complains about an extension it enabled, make it go away. Goal is to compile clean even with -Wpedantic